### PR TITLE
fix: enable backoff for deallocate-mode failed-to-start VMs

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
@@ -229,26 +229,30 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *compute.VirtualMachineScaleSe
 		status.State = cloudprovider.InstanceRunning
 
 		klog.V(3).Infof("VM %s reports failed provisioning state with power state: %s, scale down mode: %s, eligible for fast delete: %s", to.String(vm.ID), powerState, scaleSet.scaleDownPolicy, strconv.FormatBool(scaleSet.enableFastDeleteOnFailedProvisioning))
-		if scaleSet.scaleDownPolicy != deallocate.Deallocate && scaleSet.enableFastDeleteOnFailedProvisioning {
+		if scaleSet.enableFastDeleteOnFailedProvisioning {
 			// Provisioning can fail both during instance creation or after the instance is running.
 			// Per https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing#provisioning-states,
 			// ProvisioningState represents the most recent provisioning state, therefore only report
-			// InstanceCreating errors when the power state indicates the instance has not yet started running
+			// InstanceCreating errors when the power state indicates the instance has not yet started running.
+			//
+			// This relies on the fact that InstanceCreating + ErrorInfo will subsequently trigger:
+			// 1. handleInstanceCreationErrors → backoff on the node group
+			// 2. deleteCreatedNodesWithErrors → cleanup (skipped for deallocate-mode groups)
+			// Could be revisited to rely on something more stable/explicit.
 			if !isRunningVmPowerState(powerState) {
-				// This fast deletion relies on the fact that InstanceCreating + ErrorInfo will subsequently trigger a deletion.
-				// Could be revisited to rely on something more stable/explicit.
 				status.State = cloudprovider.InstanceCreating
+				errorCode := "provisioning-state-failed"
+				errorMessage := "Azure failed to provision a node for this node group"
+				if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+					errorCode = "start-deallocated-failed"
+					errorMessage = "Failed to start deallocated VM"
+				}
 				status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
 					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:    "provisioning-state-failed",
-					ErrorMessage: "Azure failed to provision a node for this node group",
+					ErrorCode:    errorCode,
+					ErrorMessage: errorMessage,
 				}
-			} else {
-				status.State = cloudprovider.InstanceRunning
 			}
-		} else if scaleSet.scaleDownPolicy == deallocate.Deallocate {
-			// Current(?) deallocate mode design handles InstanceFailed and InstanceRunning differently.
-			status.State = cloudprovider.InstanceFailed
 		}
 	default:
 		status.State = cloudprovider.InstanceRunning

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
@@ -203,11 +203,12 @@ func newTestScaleSetDeallocateModeWithFastDelete(manager *AzureManager, name str
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager:           manager,
-		minSize:           1,
-		maxSize:           5,
-		enableForceDelete: manager.config.EnableForceDelete,
-		scaleDownPolicy:   deallocate.Deallocate,
+		manager:                              manager,
+		minSize:                              1,
+		maxSize:                              5,
+		enableForceDelete:                    manager.config.EnableForceDelete,
+		enableFastDeleteOnFailedProvisioning: true,
+		scaleDownPolicy:                      deallocate.Deallocate,
 	}
 }
 
@@ -294,9 +295,11 @@ func TestGetInstancesByState(t *testing.T) {
 	scaleSet.scaleDownPolicy = deallocate.Deallocate
 
 	// t2 - cache is stale - instance with given state exists in the instanceCache
-	actualInstances, err = scaleSet.getInstancesByState(cloudprovider.InstanceFailed)
+	// VM[0] has ProvisioningState=Failed + no InstanceView (defaults to running power state)
+	// In deallocate mode, running VMs with failed provisioning are treated as InstanceRunning
+	actualInstances, err = scaleSet.getInstancesByState(cloudprovider.InstanceRunning)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(actualInstances)) // there should be only one instance with failed State
+	assert.Equal(t, 1, len(actualInstances))
 	assert.Equal(t, expectedInstanceCache[0].Id, actualInstances[0].Id)
 	assert.Equal(t, expectedInstanceCache[0].Status.State, actualInstances[0].Status.State)
 
@@ -342,11 +345,11 @@ func TestSetInstanceStatusByProviderID(t *testing.T) {
 	// t2 - cache is stale - expectInstanceCache update, set for providerID=2 will not be added to the instanceCache because
 	// it doesn't exist in the cache. GetScaleSetVms() will have not introduced instance with providerID=2
 	providerID = azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)
-	status = cloudprovider.InstanceStatus{State: cloudprovider.InstanceFailed}
+	status = cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting}
 	scaleSet.setInstanceStatusByProviderID(providerID, status) // it will not set for providerID=2 as it is not already present in the cache
-	actualInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceFailed)
+	actualInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceDeleting)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(actualInstances))
+	assert.Equal(t, 0, len(actualInstances))
 }
 
 // beforeEachNoInstanceCacheResetNeededHelper has 1 instance in the instanceCache with state = deallocated.
@@ -394,7 +397,7 @@ func TestBeforeEachInstanceCacheResetNeededHelper(t *testing.T) {
 	}
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG, string(compute.InstanceViewTypesInstanceView)).Return(
 		expectedVMSSVMs, nil)
-	expectedStates = []cloudprovider.InstanceState{cloudprovider.InstanceFailed, cloudprovider.InstanceDeallocated}
+	expectedStates = []cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeallocated}
 	expectedInstanceCache = testGetInstanceCacheWithStates(t, expectedVMSSVMs, expectedStates)
 }
 
@@ -403,6 +406,7 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 
 	scaleSet.scaleDownPolicy = deallocate.Deallocate
 	// Disabled EnableFastDelete, deallocate mode, running power state
+	// Running VMs in deallocate mode default to InstanceRunning (CSE error check handles broken VMs)
 	vm := &compute.VirtualMachineScaleSetVM{
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: to.StringPtr(string(compute.GalleryProvisioningStateFailed)),
@@ -415,9 +419,10 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status := scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 
 	// Enabled EnableFastDelete, deallocate mode, running power state
+	// Running VMs still get InstanceRunning — fast-delete doesn't apply in deallocate mode for running VMs
 	scaleSet.enableFastDeleteOnFailedProvisioning = true
 	vm = &compute.VirtualMachineScaleSetVM{
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
@@ -431,10 +436,11 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status = scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 	scaleSet.enableFastDeleteOnFailedProvisioning = false
 
 	// Enabled EnableFastDelete, deallocate mode, not running power state
+	// Non-running VMs in deallocate mode trigger backoff (InstanceCreating + ErrorInfo)
 	scaleSet.enableFastDeleteOnFailedProvisioning = true
 	vm = &compute.VirtualMachineScaleSetVM{
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
@@ -448,7 +454,10 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status = scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotNil(t, status.ErrorInfo)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+	assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 	scaleSet.enableFastDeleteOnFailedProvisioning = false
 
 	scaleSet.scaleDownPolicy = deallocate.Delete
@@ -540,6 +549,80 @@ func TestInstanceStatusFromVMEnableFastDeleteOnCSEFailure(t *testing.T) {
 	scaleSet.enableFastDeleteOnFailedProvisioning = false
 }
 
+func TestInstanceStatusFromVMDeallocateModeCSEFailure(t *testing.T) {
+	// Deallocate mode + running VM + CSE error: the CSE check should override InstanceRunning
+	// with InstanceCreating + OtherErrorClass. This is the main detection path for VMs that
+	// started but have broken extensions (Gap 2 from the tail-side error handling design).
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSetDeallocateModeWithFastDelete(provider.azureManager, "testScaleSet")
+	scaleSet.enableDetailedCSEMessage = true
+
+	vm := newVMObjectWithState(string(compute.GalleryProvisioningStateFailed), vmPowerStateRunning)
+	vm.InstanceView.Extensions = &[]compute.VirtualMachineExtensionInstanceView{
+		{
+			Name: to.StringPtr(vmssCSEExtensionName),
+			Statuses: &[]compute.InstanceViewStatus{
+				{
+					Level:   compute.Error,
+					Code:    to.StringPtr(vmssExtensionProvisioningFailed),
+					Message: to.StringPtr("Custom Script Extension failed to provision"),
+				},
+			},
+		},
+	}
+
+	status := scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotNil(t, status.ErrorInfo)
+	assert.Equal(t, cloudprovider.OtherErrorClass, status.ErrorInfo.ErrorClass)
+	assert.Equal(t, vmssExtensionProvisioningFailed, status.ErrorInfo.ErrorCode)
+}
+
+func TestInstanceStatusFromVMErrorCodeByScaleDownMode(t *testing.T) {
+	// Verify that deallocate mode and delete mode get distinct error codes
+	// under identical conditions (Failed + non-running + enableFastDelete).
+	tests := []struct {
+		name              string
+		scaleDownPolicy   deallocate.ScaleDownPolicy
+		expectedErrorCode string
+	}{
+		{
+			name:              "deallocate mode gets start-deallocated-failed",
+			scaleDownPolicy:   deallocate.Deallocate,
+			expectedErrorCode: "start-deallocated-failed",
+		},
+		{
+			name:              "delete mode gets provisioning-state-failed",
+			scaleDownPolicy:   deallocate.Delete,
+			expectedErrorCode: "provisioning-state-failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newTestProvider(t)
+			scaleSet := &ScaleSet{
+				azureRef:                             azureRef{Name: "testScaleSet"},
+				manager:                              provider.azureManager,
+				minSize:                              1,
+				maxSize:                              5,
+				enableFastDeleteOnFailedProvisioning: true,
+				scaleDownPolicy:                      tt.scaleDownPolicy,
+			}
+
+			vm := newVMObjectWithState(string(compute.GalleryProvisioningStateFailed), vmPowerStateStopped)
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+			assert.Equal(t, tt.expectedErrorCode, status.ErrorInfo.ErrorCode)
+		})
+	}
+}
+
 func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 	t.Run("fast delete enablement = false", func(t *testing.T) {
 		provider := newTestProvider(t)
@@ -547,56 +630,45 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 
 		t.Run("provisioning state = failed, power state = starting", func(t *testing.T) {
 			vm := newVMObjectWithState(string(compute.GalleryProvisioningStateFailed), vmPowerStateStarting)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Without enableFastDeleteOnFailedProvisioning, all failed VMs default to InstanceRunning
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
 			vm := newVMObjectWithState(string(compute.GalleryProvisioningStateFailed), vmPowerStateRunning)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
 			vm := newVMObjectWithState(string(compute.GalleryProvisioningStateFailed), vmPowerStateStopping)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
 			vm := newVMObjectWithState(string(compute.GalleryProvisioningStateFailed), vmPowerStateStopped)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
 			vm := newVMObjectWithState(string(compute.GalleryProvisioningStateFailed), vmPowerStateDeallocated)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
 			vm := newVMObjectWithState(string(compute.GalleryProvisioningStateFailed), vmPowerStateUnknown)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 	})
 
@@ -610,7 +682,8 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Starting is a running power state — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
@@ -619,7 +692,8 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Running VM with failed provisioning — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
@@ -628,7 +702,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopping is not a running power state — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
@@ -637,7 +714,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopped is not running — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
@@ -646,7 +726,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Deallocated VM that failed to start — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
@@ -655,7 +738,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Unknown power state (not running) — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 	})
 }

--- a/cluster-autoscaler/cloudprovider/azure/test/e2e/azure_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/e2e/azure_test.go
@@ -151,4 +151,162 @@ var _ = Describe("Azure Provider", func() {
 			))
 		}, "20m", "10s").Should(Succeed())
 	})
+
+	// TODO: This test requires a deallocate-mode node pool and the ability to induce
+	// a start failure. Uncomment and adapt once the test infrastructure supports
+	// configuring scale-down-mode on VMSS and simulating capacity errors.
+	//
+	// Design: After a deallocate-mode node pool scales down (VMs deallocated),
+	// trigger a scale-up that causes BeginStart to fail (e.g., constrained SKU).
+	// CAS should:
+	//   1. Detect the failure via instanceStatusFromVM (InstanceCreating + ErrorInfo)
+	//   2. Register a failed scale-up → exponential backoff on the node group
+	//   3. NOT delete the deallocated VMs (deleteCreatedNodesWithErrors guard)
+	//   4. Emit a ScaleUpFailed Kubernetes event
+	//
+	// Verification signals:
+	//   - K8s events: ScaleUpFailed on the node group
+	//   - CAS metrics: failed_scale_ups_total{reason="start-deallocated-failed"} > 0
+	//   - VMSS state: deallocated VMs still exist (not deleted)
+	//   - Node count: unchanged (no new nodes joined)
+	PIt("backs off deallocate-mode node groups on failed VM start", func() {
+		ensureHelmValues(map[string]interface{}{
+			"extraArgs": map[string]interface{}{
+				"scale-down-delay-after-add":       "10s",
+				"scale-down-unneeded-time":         "10s",
+				"scale-down-candidates-pool-ratio": "1.0",
+				"unremovable-node-recheck-timeout": "10s",
+				"skip-nodes-with-system-pods":      "false",
+				"skip-nodes-with-local-storage":    "false",
+			},
+		})
+
+		nodes := &corev1.NodeList{}
+		Expect(k8s.List(ctx, nodes)).To(Succeed())
+		nodeCountBefore := len(nodes.Items)
+
+		By("Creating Pods to trigger scale-up on a deallocate-mode pool")
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deallocate-backoff-test",
+				Namespace: namespace.Name,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "deallocate-backoff-test"},
+				},
+				Replicas: ptr.To[int32](10),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "deallocate-backoff-test"},
+					},
+					Spec: corev1.PodSpec{
+						// TODO: Add nodeSelector/affinity to target the deallocate-mode pool
+						Containers: []corev1.Container{
+							{
+								Name:  "pause",
+								Image: "registry.k8s.io/pause:3.9",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("200m"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8s.Create(ctx, deploy)).To(Succeed())
+
+		By("Waiting for scale-up and subsequent scale-down (VMs deallocated)")
+		Eventually(func() (int, error) {
+			readyCount := 0
+			nodes := &corev1.NodeList{}
+			if err := k8s.List(ctx, nodes); err != nil {
+				return 0, err
+			}
+			for _, node := range nodes.Items {
+				for _, cond := range node.Status.Conditions {
+					if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+						readyCount++
+						break
+					}
+				}
+			}
+			return readyCount, nil
+		}, "10m", "10s").Should(BeNumerically(">", nodeCountBefore))
+
+		By("Deleting the deployment to trigger scale-down → deallocate")
+		Expect(k8s.Delete(ctx, deploy)).To(Succeed())
+		Eventually(allVMSSStable, "20m", "30s").Should(Succeed())
+
+		// TODO: At this point, the deallocate-mode VMSS should have deallocated VMs.
+		// Now we need to induce a start failure. Options:
+		//   Option A: Use Azure SDK to set a policy/quota that prevents VM start
+		//   Option B: Use a constrained SKU that's out of capacity
+		//   Option C: Corrupt the VM's CSE so it fails on restart
+		//
+		// Then create new Pods to trigger scale-up (which will try to start deallocated VMs).
+
+		By("Creating Pods to trigger scale-up (restart of deallocated VMs)")
+		deploy2 := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deallocate-backoff-trigger",
+				Namespace: namespace.Name,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "deallocate-backoff-trigger"},
+				},
+				Replicas: ptr.To[int32](10),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "deallocate-backoff-trigger"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "pause",
+								Image: "registry.k8s.io/pause:3.9",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("200m"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8s.Create(ctx, deploy2)).To(Succeed())
+
+		By("Verifying CAS emits ScaleUpFailed event (backoff triggered)")
+		Eventually(func() bool {
+			events := &corev1.EventList{}
+			if err := k8s.List(ctx, events, client.InNamespace(namespace.Name)); err != nil {
+				return false
+			}
+			for _, event := range events.Items {
+				if event.Reason == "ScaleUpFailed" {
+					return true
+				}
+			}
+			return false
+		}, "15m", "10s").Should(BeTrue(), "Expected ScaleUpFailed event from CAS backoff")
+
+		By("Verifying deallocated VMs were NOT deleted")
+		// TODO: Use vmss client to list instances and verify deallocated VMs still exist
+		// pager := vmss.NewListPager(resourceGroup, nil)
+		// Count instances with PowerState/deallocated — should be > 0
+
+		By("Verifying node count did not increase (backoff prevented new scale-up)")
+		nodes = &corev1.NodeList{}
+		Expect(k8s.List(ctx, nodes)).To(Succeed())
+		Expect(len(nodes.Items)).To(Equal(nodeCountBefore))
+
+		By("Cleanup")
+		Expect(k8s.Delete(ctx, deploy2)).To(Succeed())
+	})
 })

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -35,6 +35,7 @@ import (
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
@@ -893,7 +894,7 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() {
 		nodeGroup := nodeGroups[nodeGroupId]
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
-		} else if sdp, ok := nodeGroup.(interface{ ScaleDownPolicy() string }); ok && sdp.ScaleDownPolicy() == "Deallocate" {
+		} else if sdp, ok := nodeGroup.(deallocate.PolicyNodeGroup); ok && sdp.ScaleDownPolicy() == deallocate.Deallocate {
 			// Deallocate-mode groups: failed-to-start VMs should be preserved for future reuse,
 			// not deleted. Backoff is still triggered via handleInstanceCreationErrors.
 			klog.V(1).Infof("Skipping deletion of %v failed nodes in deallocate-mode group %v — VMs preserved for reuse", len(nodesToDelete), nodeGroupId)

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -893,6 +893,11 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() {
 		nodeGroup := nodeGroups[nodeGroupId]
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
+		} else if sdp, ok := nodeGroup.(interface{ ScaleDownPolicy() string }); ok && sdp.ScaleDownPolicy() == "Deallocate" {
+			// Deallocate-mode groups: failed-to-start VMs should be preserved for future reuse,
+			// not deleted. Backoff is still triggered via handleInstanceCreationErrors.
+			klog.V(1).Infof("Skipping deletion of %v failed nodes in deallocate-mode group %v — VMs preserved for reuse", len(nodesToDelete), nodeGroupId)
+			continue
 		} else if nodesToDelete, err = overrideNodesToDeleteForZeroOrMax(a.NodeGroupDefaults, nodeGroup, nodesToDelete); err == nil && len(nodesToDelete) > 0 {
 			if a.ForceDeleteFailedNodes {
 				err = nodeGroup.ForceDeleteNodes(nodesToDelete)


### PR DESCRIPTION
## Summary

Enable backoff for deallocate-mode node groups when VMs fail to start.

**Fixes**: [Azure/AKS#5589](https://github.com/Azure/AKS/issues/5589)  
**Design**: [#30](https://github.com/Azure/autoscaler/pull/30)

## Problem

When `enableFastDeleteOnFailedProvisioning` is active, the fast-delete path in `instanceStatusFromVM()` has a `scaleDownPolicy != Deallocate` guard that excludes deallocate mode entirely. Instead, deallocate-mode VMs with `ProvisioningState: Failed` are set to `InstanceFailed` — a fork-specific state that no core CAS code reads. This means:

- No `handleInstanceCreationErrors` → no exponential backoff
- No priority expander failover to healthy groups
- CAS retries the same failing VMs every loop iteration
- Pods stay pending for 15–45+ min until timeout-based remediation

## Fix

**`instanceStatusFromVM()`**: Remove the `!= Deallocate` guard so `enableFastDeleteOnFailedProvisioning` applies to both modes. Non-running VMs get `InstanceCreating + ErrorInfo`, which flows through the existing `handleInstanceCreationErrors` → backoff pipeline. The error code distinguishes the mode:

| Scale-Down Mode | Error Code | `deleteCreatedNodesWithErrors` |
|----------------|-----------|-------------------------------|
| Delete | `provisioning-state-failed` | Deletes the failed VM |
| Deallocate | `start-deallocated-failed` | **Skips** deletion (VM preserved) |

Running VMs with failed provisioning stay `InstanceRunning` in both modes — the CSE error check (`enableDetailedCSEMessage`) handles broken extensions separately.

**`deleteCreatedNodesWithErrors()`**: Added a guard that skips deletion for deallocate-mode groups (checked via `ScaleDownPolicy()` interface assertion). Backoff still triggers — only the cleanup deletion is skipped, preserving VMs for future reuse.

## Files Changed

- **azure_scale_set_instance_cache.go** — Remove `!= Deallocate` guard; set error code based on `scaleDownPolicy`
- **static_autoscaler.go** — Skip `deleteCreatedNodesWithErrors` for deallocate-mode groups
- **azure_scale_set_instance_cache_test.go** — Fix `newTestScaleSetDeallocateModeWithFastDelete` (was missing `enableFastDeleteOnFailedProvisioning: true`); update expectations from `InstanceFailed` → `InstanceRunning`/`InstanceCreating`; add CSE+deallocate and error code differentiation tests
- **`test/e2e/azure_test.go`** — Draft e2e test for deallocate-mode backoff (pending, marked `PIt`)

## Testing

All 38 subtests pass:
- `TestInstanceStatusFromVM` — 12 power state × fast-delete combinations
- `TestInstanceStatusFromVMDeallocateMode` — 12 power state × fast-delete combinations  
- `TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning` — 6 mode × fast-delete × power state cases
- `TestInstanceStatusFromVMDeallocateModeCSEFailure` (**new**) — CSE override for running deallocate VMs
- `TestInstanceStatusFromVMErrorCodeByScaleDownMode` (**new**) — error code differs by mode

## Cherry-pick Plan

After merge, cherry-pick to:
- `cluster-autoscaler-release-1.32.7-aks` — conflict: different condition structure ([#37](https://github.com/Azure/autoscaler/pull/37))
- `cluster-autoscaler-release-1.33.4-aks` — clean ([#38](https://github.com/Azure/autoscaler/pull/38))
- `cluster-autoscaler-release-1.34.3-aks` — clean ([#39](https://github.com/Azure/autoscaler/pull/39))
- `cluster-autoscaler-release-1.35.0-aks` — conflict: SDK v2 types ([#40](https://github.com/Azure/autoscaler/pull/40))