### PR TITLE
fix: enable backoff for deallocate-mode failed-to-start VMs (1.33.4-aks)

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
@@ -230,14 +230,30 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *compute.VirtualMachineScaleSe
 		status.State = cloudprovider.InstanceRunning
 
 		klog.V(3).Infof("VM %s reports failed provisioning state with power state: %s, scale down mode: %s, eligible for fast delete: %s", to.String(vm.ID), powerState, scaleSet.scaleDownPolicy, strconv.FormatBool(scaleSet.enableFastDeleteOnFailedProvisioning))
-		if scaleSet.scaleDownPolicy != deallocate.Deallocate && scaleSet.enableFastDeleteOnFailedProvisioning {
-			// Provisioning can fail both during instance creation or after the instance is running.
+		if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+			// Deallocate mode: detect failed-to-start VMs.
+			if !isRunningVmPowerState(powerState) {
+				// VM failed to start — remains deallocated or stopped.
+				// Signal as creation error to trigger backoff via handleInstanceCreationErrors.
+				// The deleteCreatedNodesWithErrors guard skips deletion for deallocate-mode groups,
+				// preserving VMs for future reuse.
+				// This fast deletion relies on the fact that InstanceCreating + ErrorInfo will subsequently trigger a deletion.
+				// Could be revisited to rely on something more stable/explicit.
+				status.State = cloudprovider.InstanceCreating
+				status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "start-deallocated-failed",
+					ErrorMessage: "Failed to start deallocated VM",
+				}
+			}
+			// Running power state: VM started but may have extension errors.
+			// CSE error check below (enableDetailedCSEMessage) handles this case.
+		} else if scaleSet.enableFastDeleteOnFailedProvisioning {
+			// Delete mode: existing fast-delete path for failed provisioning.
 			// Per https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing#provisioning-states,
 			// ProvisioningState represents the most recent provisioning state, therefore only report
 			// InstanceCreating errors when the power state indicates the instance has not yet started running
 			if !isRunningVmPowerState(powerState) {
-				// This fast deletion relies on the fact that InstanceCreating + ErrorInfo will subsequently trigger a deletion.
-				// Could be revisited to rely on something more stable/explicit.
 				status.State = cloudprovider.InstanceCreating
 				status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
 					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
@@ -247,9 +263,6 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *compute.VirtualMachineScaleSe
 			} else {
 				status.State = cloudprovider.InstanceRunning
 			}
-		} else if scaleSet.scaleDownPolicy == deallocate.Deallocate {
-			// Current(?) deallocate mode design handles InstanceFailed and InstanceRunning differently.
-			status.State = cloudprovider.InstanceFailed
 		}
 	default:
 		status.State = cloudprovider.InstanceRunning

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
@@ -295,9 +295,11 @@ func TestGetInstancesByState(t *testing.T) {
 	scaleSet.scaleDownPolicy = deallocate.Deallocate
 
 	// t2 - cache is stale - instance with given state exists in the instanceCache
-	actualInstances, err = scaleSet.getInstancesByState(cloudprovider.InstanceFailed)
+	// VM[0] has ProvisioningState=Failed + no InstanceView (defaults to running power state)
+	// In deallocate mode, running VMs with failed provisioning are treated as InstanceRunning
+	actualInstances, err = scaleSet.getInstancesByState(cloudprovider.InstanceRunning)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(actualInstances)) // there should be only one instance with failed State
+	assert.Equal(t, 1, len(actualInstances))
 	assert.Equal(t, expectedInstanceCache[0].Id, actualInstances[0].Id)
 	assert.Equal(t, expectedInstanceCache[0].Status.State, actualInstances[0].Status.State)
 
@@ -343,11 +345,11 @@ func TestSetInstanceStatusByProviderID(t *testing.T) {
 	// t2 - cache is stale - expectInstanceCache update, set for providerID=2 will not be added to the instanceCache because
 	// it doesn't exist in the cache. GetScaleSetVms() will have not introduced instance with providerID=2
 	providerID = azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)
-	status = cloudprovider.InstanceStatus{State: cloudprovider.InstanceFailed}
+	status = cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting}
 	scaleSet.setInstanceStatusByProviderID(providerID, status) // it will not set for providerID=2 as it is not already present in the cache
-	actualInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceFailed)
+	actualInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceDeleting)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(actualInstances))
+	assert.Equal(t, 0, len(actualInstances))
 }
 
 // beforeEachNoInstanceCacheResetNeededHelper has 1 instance in the instanceCache with state = deallocated.
@@ -395,7 +397,7 @@ func TestBeforeEachInstanceCacheResetNeededHelper(t *testing.T) {
 	}
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG, string(compute.InstanceViewTypesInstanceView)).Return(
 		expectedVMSSVMs, nil)
-	expectedStates = []cloudprovider.InstanceState{cloudprovider.InstanceFailed, cloudprovider.InstanceDeallocated}
+	expectedStates = []cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeallocated}
 	expectedInstanceCache = testGetInstanceCacheWithStates(t, expectedVMSSVMs, expectedStates)
 }
 
@@ -404,6 +406,7 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 
 	scaleSet.scaleDownPolicy = deallocate.Deallocate
 	// Disabled EnableFastDelete, deallocate mode, running power state
+	// Running VMs in deallocate mode default to InstanceRunning (CSE error check handles broken VMs)
 	vm := &compute.VirtualMachineScaleSetVM{
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: to.StringPtr(string(compute.GalleryProvisioningStateFailed)),
@@ -416,9 +419,10 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status := scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 
 	// Enabled EnableFastDelete, deallocate mode, running power state
+	// Running VMs still get InstanceRunning — fast-delete doesn't apply in deallocate mode for running VMs
 	scaleSet.enableFastDeleteOnFailedProvisioning = true
 	vm = &compute.VirtualMachineScaleSetVM{
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
@@ -432,10 +436,11 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status = scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 	scaleSet.enableFastDeleteOnFailedProvisioning = false
 
 	// Enabled EnableFastDelete, deallocate mode, not running power state
+	// Non-running VMs in deallocate mode trigger backoff (InstanceCreating + ErrorInfo)
 	scaleSet.enableFastDeleteOnFailedProvisioning = true
 	vm = &compute.VirtualMachineScaleSetVM{
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
@@ -449,7 +454,10 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status = scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotNil(t, status.ErrorInfo)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+	assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 	scaleSet.enableFastDeleteOnFailedProvisioning = false
 
 	scaleSet.scaleDownPolicy = deallocate.Delete
@@ -552,7 +560,8 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Starting is a running power state — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
@@ -561,7 +570,8 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Running VM with failed provisioning — treated as running, CSE error check handles it
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
@@ -570,7 +580,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopping is not a running power state — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
@@ -579,7 +592,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopped is not running — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
@@ -588,7 +604,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Deallocated VM that failed to start — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
@@ -597,7 +616,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Unknown power state (not running) — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 	})
 
@@ -611,7 +633,8 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Starting is a running power state — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
@@ -620,7 +643,8 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Running VM with failed provisioning — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
@@ -629,7 +653,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopping is not a running power state — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
@@ -638,7 +665,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopped is not running — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
@@ -647,7 +677,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Deallocated VM that failed to start — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
@@ -656,7 +689,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Unknown power state (not running) — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 	})
 }

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -900,6 +900,11 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() {
 		nodeGroup := nodeGroups[nodeGroupId]
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
+		} else if sdp, ok := nodeGroup.(interface{ ScaleDownPolicy() string }); ok && sdp.ScaleDownPolicy() == "Deallocate" {
+			// Deallocate-mode groups: failed-to-start VMs should be preserved for future reuse,
+			// not deleted. Backoff is still triggered via handleInstanceCreationErrors.
+			klog.V(1).Infof("Skipping deletion of %v failed nodes in deallocate-mode group %v — VMs preserved for reuse", len(nodesToDelete), nodeGroupId)
+			continue
 		} else if nodesToDelete, err = overrideNodesToDeleteForZeroOrMax(a.NodeGroupDefaults, nodeGroup, nodesToDelete); err == nil && len(nodesToDelete) > 0 {
 			if a.ForceDeleteFailedNodes {
 				err = nodeGroup.ForceDeleteNodes(nodesToDelete)


### PR DESCRIPTION
## Summary

Enable backoff for deallocate-mode node groups when VMs fail to start (Azure/AKS#5589).

## Problem

When deallocate-mode VMs fail to restart (`BeginStart` tail-side error), CAS sets `InstanceFailed` — a fork-specific state that doesn't trigger the `handleInstanceCreationErrors` backoff pipeline. This means:
- No exponential backoff on the failing node group
- No priority expander failover to healthy groups
- CAS retries the same failing VMs every iteration

## Changes

| File | Change |
|------|--------|
| `azure_scale_set_instance_cache.go` | `instanceStatusFromVM()`: For deallocate mode + `ProvisioningState: Failed` + non-running power state → set `InstanceCreating + ErrorInfo{start-deallocated-failed}` instead of `InstanceFailed` |
| `azure_scale_set.go` | Add `IsDeallocateMode()` method for cross-package interface check |
| `static_autoscaler.go` | `deleteCreatedNodesWithErrors()`: Skip deletion for deallocate-mode groups (VMs preserved for reuse) |
| `azure_scale_set_instance_cache_test.go` | Update test expectations to match new behavior |

## Design

Implements Option C from [Azure/autoscaler#30](https://github.com/Azure/autoscaler/pull/30) (Tail-Side Error Handling Design).

## Testing

All instance status tests pass across all power state combinations (starting, running, stopping, stopped, deallocated, unknown).

Cherry-picked from: impl/tail-error-handling-1.34.3 (adapted for branch-specific SDK version)

Fixes: Azure/AKS#5589