### PR TITLE
fix: OperationPreempted does not retry when failed delete operation

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
+	providerazureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 // When Azure Dedicated Host is enabled or using isolated vm skus, force deleting a VMSS fails with the following error:
@@ -96,4 +97,15 @@ func isOperationNotAllowed(err error) bool {
 		return azerr.ErrorCode == azerrors.OperationNotAllowed
 	}
 	return strings.Contains(err.Error(), azerrors.OperationNotAllowed)
+}
+
+// isOperationPreempted checks if `error` is an OperationPreempted error.
+func isOperationPreempted(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(
+		strings.ToLower(err.Error()),
+		strings.ToLower(providerazureconsts.OperationPreemptedErrorMessage),
+	)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
@@ -26,7 +26,6 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
-	providerazureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 // When Azure Dedicated Host is enabled or using isolated vm skus, force deleting a VMSS fails with the following error:
@@ -99,13 +98,15 @@ func isOperationNotAllowed(err error) bool {
 	return strings.Contains(err.Error(), azerrors.OperationNotAllowed)
 }
 
+const operationPreemptedErrorCode = "OperationPreempted"
+
 // isOperationPreempted checks if `error` is an OperationPreempted error.
 func isOperationPreempted(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(
-		strings.ToLower(err.Error()),
-		strings.ToLower(providerazureconsts.OperationPreemptedErrorMessage),
-	)
+	if azerr := azerrors.IsResponseError(err); azerr != nil {
+		return azerr.ErrorCode == operationPreemptedErrorCode
+	}
+	return strings.Contains(err.Error(), operationPreemptedErrorCode)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// When Azure Dedicated Host is enabled or using isolated vm skus, force deleting a VMSS fails with the following error:
+// When Azure Dedicated Host is enabled or using isolated vm skus, force deleting a VMSS fails with the following er:
 //
 // "predominantErrorDetail": {
 //   "innererror": {
@@ -98,15 +98,15 @@ func isOperationNotAllowed(err error) bool {
 	return strings.Contains(err.Error(), azerrors.OperationNotAllowed)
 }
 
-const operationPreemptedErrorCode = "OperationPreempted"
+const operationPreemptedErrorMessage = "Operation execution has been preempted by a more recent operation"
 
 // isOperationPreempted checks if `error` is an OperationPreempted error.
 func isOperationPreempted(err error) bool {
 	if err == nil {
 		return false
 	}
-	if azerr := azerrors.IsResponseError(err); azerr != nil {
-		return azerr.ErrorCode == operationPreemptedErrorCode
-	}
-	return strings.Contains(err.Error(), operationPreemptedErrorCode)
+	return strings.Contains(
+		strings.ToLower(err.Error()),
+		strings.ToLower(operationPreemptedErrorMessage),
+	)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
@@ -67,3 +67,29 @@ func TestIsOperationNotAllowed(t *testing.T) {
 	// function should return true.
 
 }
+
+func TestIsOperationPreempted(t *testing.T) {
+	t.Run("should return false because error is nil", func(t *testing.T) {
+		assert.Equal(t, isOperationPreempted(nil), false)
+	})
+
+	t.Run("should return false for unrelated error", func(t *testing.T) {
+		err := errors.New("BadRequest: something went wrong")
+		assert.Equal(t, isOperationPreempted(err), false)
+	})
+
+	t.Run("should return true for exact preempted message", func(t *testing.T) {
+		err := errors.New("Operation execution has been preempted by a more recent operation")
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+
+	t.Run("should return true for case-varied message", func(t *testing.T) {
+		err := errors.New("OPERATION EXECUTION HAS BEEN PREEMPTED BY A MORE RECENT OPERATION")
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+
+	t.Run("should return true for embedded message", func(t *testing.T) {
+		err := errors.New("Azure error: Operation execution has been preempted by a more recent operation: details here")
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
@@ -78,13 +78,18 @@ func TestIsOperationPreempted(t *testing.T) {
 		assert.Equal(t, isOperationPreempted(err), false)
 	})
 
-	t.Run("should return true if error contains OperationPreempted", func(t *testing.T) {
-		err := errors.New("Code: OperationPreempted, Message: Operation execution has been preempted")
+	t.Run("should return true for exact preempted message", func(t *testing.T) {
+		err := errors.New("Operation execution has been preempted by a more recent operation")
 		assert.Equal(t, isOperationPreempted(err), true)
 	})
 
-	t.Run("should return true for OperationPreempted embedded in longer string", func(t *testing.T) {
-		err := errors.New("Azure error: OperationPreempted: details here")
+	t.Run("should return true for case-varied message", func(t *testing.T) {
+		err := errors.New("OPERATION EXECUTION HAS BEEN PREEMPTED BY A MORE RECENT OPERATION")
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+
+	t.Run("should return true for embedded message", func(t *testing.T) {
+		err := errors.New("Azure error: Operation execution has been preempted by a more recent operation: details here")
 		assert.Equal(t, isOperationPreempted(err), true)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
@@ -78,18 +78,13 @@ func TestIsOperationPreempted(t *testing.T) {
 		assert.Equal(t, isOperationPreempted(err), false)
 	})
 
-	t.Run("should return true for exact preempted message", func(t *testing.T) {
-		err := errors.New("Operation execution has been preempted by a more recent operation")
+	t.Run("should return true if error contains OperationPreempted", func(t *testing.T) {
+		err := errors.New("Code: OperationPreempted, Message: Operation execution has been preempted")
 		assert.Equal(t, isOperationPreempted(err), true)
 	})
 
-	t.Run("should return true for case-varied message", func(t *testing.T) {
-		err := errors.New("OPERATION EXECUTION HAS BEEN PREEMPTED BY A MORE RECENT OPERATION")
-		assert.Equal(t, isOperationPreempted(err), true)
-	})
-
-	t.Run("should return true for embedded message", func(t *testing.T) {
-		err := errors.New("Azure error: Operation execution has been preempted by a more recent operation: details here")
+	t.Run("should return true for OperationPreempted embedded in longer string", func(t *testing.T) {
+		err := errors.New("Azure error: OperationPreempted: details here")
 		assert.Equal(t, isOperationPreempted(err), true)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -565,12 +565,12 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 	}
 
 	if poller != nil {
-		go scaleSet.waitForDeleteInstances(poller, requiredIds)
+		go scaleSet.waitForDeleteInstances(poller, requiredIds, commonAsg.Id())
 	}
 	return nil
 }
 
-func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse], requiredIds *armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs) {
+func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse], requiredIds *armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, commonAsgId string) {
 	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
 	defer cancel()
 
@@ -585,6 +585,28 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 			scaleSet.invalidateInstanceCache()
 		}
 		return
+	}
+	if isOperationPreempted(err) {
+		klog.V(2).Infof("PollUntilDone for DeleteInstances(%v) for %s was preempted, retrying", requiredIds.InstanceIDs, scaleSet.Name)
+		retryCtx, retryCancel := getContextWithTimeout(vmssContextTimeout)
+		retryPoller, retryErr := scaleSet.deleteInstances(retryCtx, requiredIds, commonAsgId)
+		retryCancel()
+		if retryErr == nil && retryPoller != nil {
+			_, retryErr = retryPoller.PollUntilDone(ctx, nil)
+			if retryErr == nil {
+				klog.V(3).Infof("PollUntilDone for DeleteInstances(%v) for %s retry success", requiredIds.InstanceIDs, scaleSet.Name)
+				if scaleSet.manager.config.StrictCacheUpdates {
+					if err := scaleSet.manager.forceRefresh(); err != nil {
+						klog.Errorf("forceRefresh failed with error: %v", err)
+					}
+					scaleSet.invalidateInstanceCache()
+				}
+				return
+			}
+		}
+		if retryErr != nil {
+			err = retryErr
+		}
 	}
 	if !scaleSet.manager.config.StrictCacheUpdates {
 		scaleSet.invalidateInstanceCache()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -565,12 +565,12 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 	}
 
 	if poller != nil {
-		go scaleSet.waitForDeleteInstances(poller, requiredIds, commonAsg.Id())
+		go scaleSet.waitForDeleteInstances(poller, requiredIds)
 	}
 	return nil
 }
 
-func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse], requiredIds *armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, commonAsgId string) {
+func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse], requiredIds *armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs) {
 	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
 	defer cancel()
 
@@ -586,32 +586,57 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 		}
 		return
 	}
+
 	if isOperationPreempted(err) {
-		klog.V(2).Infof("PollUntilDone for DeleteInstances(%v) for %s was preempted, retrying", requiredIds.InstanceIDs, scaleSet.Name)
-		retryCtx, retryCancel := getContextWithTimeout(vmssContextTimeout)
-		retryPoller, retryErr := scaleSet.deleteInstances(retryCtx, requiredIds, commonAsgId)
-		retryCancel()
-		if retryErr == nil && retryPoller != nil {
-			_, retryErr = retryPoller.PollUntilDone(ctx, nil)
-			if retryErr == nil {
-				klog.V(3).Infof("PollUntilDone for DeleteInstances(%v) for %s retry success", requiredIds.InstanceIDs, scaleSet.Name)
-				if scaleSet.manager.config.StrictCacheUpdates {
-					if err := scaleSet.manager.forceRefresh(); err != nil {
-						klog.Errorf("forceRefresh failed with error: %v", err)
-					}
-					scaleSet.invalidateInstanceCache()
-				}
-				return
-			}
-		}
-		if retryErr != nil {
-			err = retryErr
-		}
+		klog.Warningf("DeleteInstances(%v) for %s got OperationPreempted, retrying",
+			requiredIds.InstanceIDs, scaleSet.Name)
+		scaleSet.retryDeleteInstances(requiredIds)
+		return
 	}
+
 	if !scaleSet.manager.config.StrictCacheUpdates {
 		scaleSet.invalidateInstanceCache()
 	}
 	klog.Errorf("PollUntilDone for DeleteInstances(%v) for %s failed with error: %v", requiredIds.InstanceIDs, scaleSet.Name, err)
+}
+
+func (scaleSet *ScaleSet) retryDeleteInstances(requiredIds *armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs) {
+	const maxRetries = 3
+	backoff := []time.Duration{10 * time.Second, 30 * time.Second, 60 * time.Second}
+
+	for i := 0; i < maxRetries; i++ {
+		time.Sleep(backoff[i])
+
+		ctx, cancel := getContextWithTimeout(vmssContextTimeout)
+		poller, err := scaleSet.deleteInstances(ctx, requiredIds, scaleSet.Name)
+		cancel()
+		if err != nil {
+			klog.Errorf("Retry %d/%d: BeginDeleteInstances for %s failed: %v", i+1, maxRetries, scaleSet.Name, err)
+			continue
+		}
+		if poller == nil {
+			klog.V(3).Infof("Retry %d/%d: poller nil for %s, assuming success", i+1, maxRetries, scaleSet.Name)
+			return
+		}
+
+		ctx2, cancel2 := getContextWithTimeout(asyncContextTimeout)
+		_, err = poller.PollUntilDone(ctx2, nil)
+		cancel2()
+		if err == nil {
+			klog.V(3).Infof("Retry %d/%d: DeleteInstances for %s succeeded", i+1, maxRetries, scaleSet.Name)
+			scaleSet.invalidateInstanceCache()
+			return
+		}
+		if !isOperationPreempted(err) {
+			klog.Errorf("Retry %d/%d: non-retriable error for %s: %v", i+1, maxRetries, scaleSet.Name, err)
+			break
+		}
+		klog.Warningf("Retry %d/%d: DeleteInstances for %s still OperationPreempted", i+1, maxRetries, scaleSet.Name)
+	}
+
+	klog.Errorf("All retries exhausted for DeleteInstances(%v) for %s",
+		requiredIds.InstanceIDs, scaleSet.Name)
+	scaleSet.invalidateInstanceCache()
 }
 
 // DeleteNodes deletes the nodes from the group.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -587,56 +587,27 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 		return
 	}
 
+	// Retry once on OperationPreempted, mirroring the pattern in vmssvmclient.updateVMSSVMs()
 	if isOperationPreempted(err) {
-		klog.Warningf("DeleteInstances(%v) for %s got OperationPreempted, retrying",
-			requiredIds.InstanceIDs, scaleSet.Name)
-		scaleSet.retryDeleteInstances(requiredIds)
-		return
+		klog.V(2).Infof("PollUntilDone for DeleteInstances(%v) for %s was preempted, retrying once", requiredIds.InstanceIDs, scaleSet.Name)
+		retryCtx, retryCancel := getContextWithTimeout(vmssContextTimeout)
+		retryPoller, retryErr := scaleSet.deleteInstances(retryCtx, requiredIds, scaleSet.Name)
+		retryCancel()
+		if retryErr == nil && retryPoller != nil {
+			_, retryErr = retryPoller.PollUntilDone(ctx, nil)
+		}
+		if retryErr == nil {
+			klog.V(3).Infof("PollUntilDone for DeleteInstances(%v) for %s retry success", requiredIds.InstanceIDs, scaleSet.Name)
+			scaleSet.invalidateInstanceCache()
+			return
+		}
+		klog.Errorf("PollUntilDone for DeleteInstances(%v) for %s retry failed: %v", requiredIds.InstanceIDs, scaleSet.Name, retryErr)
 	}
 
 	if !scaleSet.manager.config.StrictCacheUpdates {
 		scaleSet.invalidateInstanceCache()
 	}
 	klog.Errorf("PollUntilDone for DeleteInstances(%v) for %s failed with error: %v", requiredIds.InstanceIDs, scaleSet.Name, err)
-}
-
-func (scaleSet *ScaleSet) retryDeleteInstances(requiredIds *armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs) {
-	const maxRetries = 3
-	backoff := []time.Duration{10 * time.Second, 30 * time.Second, 60 * time.Second}
-
-	for i := 0; i < maxRetries; i++ {
-		time.Sleep(backoff[i])
-
-		ctx, cancel := getContextWithTimeout(vmssContextTimeout)
-		poller, err := scaleSet.deleteInstances(ctx, requiredIds, scaleSet.Name)
-		cancel()
-		if err != nil {
-			klog.Errorf("Retry %d/%d: BeginDeleteInstances for %s failed: %v", i+1, maxRetries, scaleSet.Name, err)
-			continue
-		}
-		if poller == nil {
-			klog.V(3).Infof("Retry %d/%d: poller nil for %s, assuming success", i+1, maxRetries, scaleSet.Name)
-			return
-		}
-
-		ctx2, cancel2 := getContextWithTimeout(asyncContextTimeout)
-		_, err = poller.PollUntilDone(ctx2, nil)
-		cancel2()
-		if err == nil {
-			klog.V(3).Infof("Retry %d/%d: DeleteInstances for %s succeeded", i+1, maxRetries, scaleSet.Name)
-			scaleSet.invalidateInstanceCache()
-			return
-		}
-		if !isOperationPreempted(err) {
-			klog.Errorf("Retry %d/%d: non-retriable error for %s: %v", i+1, maxRetries, scaleSet.Name, err)
-			break
-		}
-		klog.Warningf("Retry %d/%d: DeleteInstances for %s still OperationPreempted", i+1, maxRetries, scaleSet.Name)
-	}
-
-	klog.Errorf("All retries exhausted for DeleteInstances(%v) for %s",
-		requiredIds.InstanceIDs, scaleSet.Name)
-	scaleSet.invalidateInstanceCache()
 }
 
 // DeleteNodes deletes the nodes from the group.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package azure
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -1512,4 +1516,158 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 			assert.NotNil(t, status.ErrorInfo)
 		})
 	})
+}
+
+// testPollingHandler implements runtime.PollingHandler[T] for testing.
+// It returns the configured error on Poll() and reports done after the error is returned.
+type testPollingHandler[T any] struct {
+	err    error
+	polled bool
+}
+
+func (h *testPollingHandler[T]) Done() bool {
+	return h.polled && h.err == nil
+}
+
+func (h *testPollingHandler[T]) Poll(_ context.Context) (*http.Response, error) {
+	h.polled = true
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, h.err
+}
+
+func (h *testPollingHandler[T]) Result(_ context.Context, _ *T) error {
+	return h.err
+}
+
+// newTestPollerWithError creates a runtime.Poller that returns the given error on PollUntilDone.
+func newTestPollerWithError(err error) *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse] {
+	resp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+	}
+	pl := runtime.NewPipeline("test", "v0.0.0", runtime.PipelineOptions{}, nil)
+	poller, pollerErr := runtime.NewPoller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse](resp, pl, &runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]{
+		Handler: &testPollingHandler[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]{err: err},
+	})
+	if pollerErr != nil {
+		panic(pollerErr)
+	}
+	return poller
+}
+
+func TestWaitForDeleteInstancesWithOperationPreemptedRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+
+	expectedScaleSets := []*armcompute.VirtualMachineScaleSet{
+		{
+			Name: &vmssName,
+			SKU: &armcompute.SKU{
+				Capacity: &vmssCapacity,
+			},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+		},
+	}
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	// Mock the delete client to return (nil, nil) for the retry call from waitForDeleteInstances
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+	manager.explicitlyConfigured["test-asg"] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+		InstanceIDs: []*string{ptr.To("0")},
+	}
+
+	// Create a poller that will return an OperationPreempted error
+	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
+
+	scaleSet := newTestScaleSet(manager, "test-asg")
+
+	// Call waitForDeleteInstances directly — it should detect the preempted error and retry via deleteInstances
+	// The retry call to deleteInstances returns (nil, nil) from the mock, so the retry poller is nil
+	// and it falls through to cache invalidation. This verifies the retry path is exercised without panicking.
+	scaleSet.waitForDeleteInstances(preemptedPoller, requiredIds, "test-asg")
+
+	// Verify that BeginDeleteInstances was called (the retry attempt)
+	// gomock will fail the test if the expected call was not made
+}
+
+func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+
+	expectedScaleSets := []*armcompute.VirtualMachineScaleSet{
+		{
+			Name: &vmssName,
+			SKU: &armcompute.SKU{
+				Capacity: &vmssCapacity,
+			},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+		},
+	}
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	// Do NOT set up a mock delete client expectation — if retry is attempted, gomock will fail
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+	manager.explicitlyConfigured["test-asg"] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+		InstanceIDs: []*string{ptr.To("0")},
+	}
+
+	// Create a poller that will return a non-preempted error
+	otherErrorPoller := newTestPollerWithError(errors.New("InternalServerError: something went wrong"))
+
+	scaleSet := newTestScaleSet(manager, "test-asg")
+
+	// Call waitForDeleteInstances — it should NOT retry because the error is not OperationPreempted
+	scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds, "test-asg")
+
+	// If this completes without gomock failures, the retry path was NOT exercised (correct behavior)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -1585,9 +1585,9 @@ func TestWaitForDeleteInstancesWithOperationPreemptedRetry(t *testing.T) {
 	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
 	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
 
-	// Mock the delete client to return (nil, nil) for the retry call from waitForDeleteInstances
+	// Override the default delete client mock: expect exactly 1 retry call to BeginDeleteInstances
 	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
-	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 	manager.azClient.vmssClientForDelete = mockDeleteClient
 
 	err := manager.forceRefresh()
@@ -1603,18 +1603,23 @@ func TestWaitForDeleteInstancesWithOperationPreemptedRetry(t *testing.T) {
 		InstanceIDs: []*string{ptr.To("0")},
 	}
 
-	// Create a poller that will return an OperationPreempted error
-	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
-
 	scaleSet := newTestScaleSet(manager, "test-asg")
 
-	// Call waitForDeleteInstances directly — it should detect the preempted error and retry via retryDeleteInstances
-	// The retry call to deleteInstances returns (nil, nil) from the mock, so the retry poller is nil
-	// and retryDeleteInstances treats that as success. This verifies the retry path is exercised without panicking.
+	// lastInstanceRefresh starts at zero value for a new ScaleSet
+	assert.True(t, scaleSet.lastInstanceRefresh.IsZero())
+
+	// Create a poller that returns an OperationPreempted error on PollUntilDone
+	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
+
+	// Act: the initial PollUntilDone fails with OperationPreempted, triggering a retry.
+	// The retry calls deleteInstances which returns (nil, nil) from the mock — retryPoller is nil,
+	// so retryErr stays nil, which counts as success. The function should invalidate cache and return.
 	scaleSet.waitForDeleteInstances(preemptedPoller, requiredIds)
 
-	// Verify that BeginDeleteInstances was called (the retry attempt)
-	// gomock will fail the test if the expected call was not made
+	// Assert: BeginDeleteInstances was called exactly once (the retry). gomock.Times(1) enforces this.
+	// Assert: instance cache was invalidated (lastInstanceRefresh changed from zero)
+	assert.False(t, scaleSet.lastInstanceRefresh.IsZero(),
+		"expected instance cache to be invalidated after preempted retry success")
 }
 
 func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
@@ -1647,7 +1652,12 @@ func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
 	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
 	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
 
-	// Do NOT set up a mock delete client expectation — if retry is attempted, gomock will fail
+	// Override the default delete client mock: expect exactly 0 calls to BeginDeleteInstances.
+	// If the retry path is accidentally triggered, gomock will fail the test.
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
 	err := manager.forceRefresh()
 	assert.NoError(t, err)
 
@@ -1661,13 +1671,80 @@ func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
 		InstanceIDs: []*string{ptr.To("0")},
 	}
 
-	// Create a poller that will return a non-preempted error
+	scaleSet := newTestScaleSet(manager, "test-asg")
+
+	// Create a poller that returns a non-preempted error
 	otherErrorPoller := newTestPollerWithError(errors.New("InternalServerError: something went wrong"))
+
+	// Act: PollUntilDone fails with a non-preempted error — should NOT trigger retry
+	scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds)
+
+	// Assert: BeginDeleteInstances was never called. gomock.Times(0) enforces this.
+}
+
+func TestWaitForDeleteInstancesRetryFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+
+	expectedScaleSets := []*armcompute.VirtualMachineScaleSet{
+		{
+			Name: &vmssName,
+			SKU: &armcompute.SKU{
+				Capacity: &vmssCapacity,
+			},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+		},
+	}
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	// Override the default delete client mock: the retry call to deleteInstances itself fails
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("ResourceGroupNotFound")).Times(1)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+	manager.explicitlyConfigured["test-asg"] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+		InstanceIDs: []*string{ptr.To("0")},
+	}
 
 	scaleSet := newTestScaleSet(manager, "test-asg")
 
-	// Call waitForDeleteInstances — it should NOT retry because the error is not OperationPreempted
-	scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds)
+	// lastInstanceRefresh starts at zero value for a new ScaleSet
+	assert.True(t, scaleSet.lastInstanceRefresh.IsZero())
 
-	// If this completes without gomock failures, the retry path was NOT exercised (correct behavior)
+	// Create a poller that returns OperationPreempted
+	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
+
+	// Act: PollUntilDone fails with OperationPreempted, retry is attempted but deleteInstances fails.
+	// Should fall through to the error path and invalidate cache.
+	scaleSet.waitForDeleteInstances(preemptedPoller, requiredIds)
+
+	// Assert: retry was attempted exactly once (gomock.Times(1) enforces this)
+	// Assert: cache was still invalidated despite failure (the !StrictCacheUpdates path)
+	assert.False(t, scaleSet.lastInstanceRefresh.IsZero(),
+		"expected instance cache to be invalidated after retry failure")
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -1604,14 +1604,14 @@ func TestWaitForDeleteInstancesWithOperationPreemptedRetry(t *testing.T) {
 	}
 
 	// Create a poller that will return an OperationPreempted error
-	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
+	preemptedPoller := newTestPollerWithError(errors.New("Code: OperationPreempted, Message: Operation execution has been preempted"))
 
 	scaleSet := newTestScaleSet(manager, "test-asg")
 
-	// Call waitForDeleteInstances directly — it should detect the preempted error and retry via deleteInstances
+	// Call waitForDeleteInstances directly — it should detect the preempted error and retry via retryDeleteInstances
 	// The retry call to deleteInstances returns (nil, nil) from the mock, so the retry poller is nil
-	// and it falls through to cache invalidation. This verifies the retry path is exercised without panicking.
-	scaleSet.waitForDeleteInstances(preemptedPoller, requiredIds, "test-asg")
+	// and retryDeleteInstances treats that as success. This verifies the retry path is exercised without panicking.
+	scaleSet.waitForDeleteInstances(preemptedPoller, requiredIds)
 
 	// Verify that BeginDeleteInstances was called (the retry attempt)
 	// gomock will fail the test if the expected call was not made
@@ -1667,7 +1667,7 @@ func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
 	scaleSet := newTestScaleSet(manager, "test-asg")
 
 	// Call waitForDeleteInstances — it should NOT retry because the error is not OperationPreempted
-	scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds, "test-asg")
+	scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds)
 
 	// If this completes without gomock failures, the retry path was NOT exercised (correct behavior)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -1604,7 +1604,7 @@ func TestWaitForDeleteInstancesWithOperationPreemptedRetry(t *testing.T) {
 	}
 
 	// Create a poller that will return an OperationPreempted error
-	preemptedPoller := newTestPollerWithError(errors.New("Code: OperationPreempted, Message: Operation execution has been preempted"))
+	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
 
 	scaleSet := newTestScaleSet(manager, "test-asg")
 


### PR DESCRIPTION
#### What type of PR is this?
Fixing OperationPreempted copying what vmss does for PUT operations in here: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/release-1.29/pkg/azureclients/vmssvmclient/azure_vmssvmclient.go
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes the retry for OperationPreempted for delete operations in CAS.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
