### PR TITLE
Update builder Go image to MCR golang 1.25.0

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.24.0
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0
 
 ENV GOPATH /gopath/
 ENV PATH $GOPATH/bin:$PATH


### PR DESCRIPTION
## Summary
Update the builder Dockerfile Go image from `mcr.microsoft.com/oss/go/microsoft/golang:1.24.0` to `mcr.microsoft.com/oss/go/microsoft/golang:1.25.0` to align with the Go 1.25 version used by upstream master.

## Changes
- **builder/Dockerfile**: Updated Go image tag from `1.24.0` to `1.25.0`

## Validation
- cluster-autoscaler builds successfully
- All cluster-autoscaler unit tests pass (pre-existing vendor SDK failures in Baidu, Civo, Huawei, OCI, Volcengine are unrelated)