### PR TITLE
fix: race condition in deallocate mode with delete instance and running instance

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -694,9 +694,14 @@ func (scaleSet *ScaleSet) waitForDeallocateInstances(poller *runtime.Poller[armc
 	if err == nil {
 		klog.V(3).Infof("PollUntilDone for Deallocate(%v) for %s success",
 			instanceIDs, scaleSet.Name)
-		// Set the status of the instances to deallocated only if PollUntilDone succeeds
+		// Set the status of the instances to deallocated only if PollUntilDone succeeds.
+		// Use setInstanceStatusIfNotSuperseded to avoid overwriting state set by a newer
+		// concurrent operation (e.g., startInstance setting InstanceRunning, or DeleteInstances
+		// setting InstanceDeleting) that occurred while this goroutine was waiting.
 		for _, instance := range instancesToDeallocate {
-			scaleSet.setInstanceStatusByProviderID(instance.Name, cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated})
+			scaleSet.setInstanceStatusIfNotSuperseded(instance.Name,
+				cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+				[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
 		}
 		return
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -698,6 +698,10 @@ func (scaleSet *ScaleSet) waitForDeallocateInstances(poller *runtime.Poller[armc
 		// Use setInstanceStatusIfNotSuperseded to avoid overwriting state set by a newer
 		// concurrent operation (e.g., startInstance setting InstanceRunning, or DeleteInstances
 		// setting InstanceDeleting) that occurred while this goroutine was waiting.
+		// In the happy path, instance state here is InstanceDeallocating (set proactively by
+		// deallocateInstances before launching this goroutine). InstanceRunning and InstanceDeleting
+		// are only possible if a concurrent startInstance or DeleteInstances raced with this
+		// deallocate operation — those newer operations take precedence.
 		for _, instance := range instancesToDeallocate {
 			scaleSet.setInstanceStatusIfNotSuperseded(instance.Name,
 				cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_deallocate_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_deallocate_test.go
@@ -365,7 +365,52 @@ func TestWaitForDeallocateInstances(t *testing.T) {
 		asg.instanceMutex.Unlock()
 	})
 
-	t.Run("failure: cache is invalidated", func(t *testing.T) {
+	t.Run("success: instance started concurrently is not overwritten", func(t *testing.T) {
+		// Reset states to Deallocating (simulating in-flight deallocate)
+		for i := range asg.instanceCache {
+			asg.instanceCache[i].Status.State = cloudprovider.InstanceDeallocating
+		}
+		// Simulate a concurrent startInstance having set instance 1 to Running
+		// while the deallocate poller was in flight
+		asg.instanceCache[1].Status.State = cloudprovider.InstanceRunning
+
+		asg.instanceMutex.Lock()
+		asg.lastInstanceRefresh = time.Now()
+		asg.instanceMutex.Unlock()
+
+		poller := newFakeDeallocatePoller(&fakeSuccessHandler[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]{})
+		asg.waitForDeallocateInstances(poller, instanceRefs, []*string{})
+
+		// Instance 0 and 2 should transition to Deallocated
+		assert.Equal(t, cloudprovider.InstanceDeallocated, asg.instanceCache[0].Status.State)
+		assert.Equal(t, cloudprovider.InstanceDeallocated, asg.instanceCache[2].Status.State)
+		// Instance 1 should remain Running — the newer startInstance operation takes precedence
+		assert.Equal(t, cloudprovider.InstanceRunning, asg.instanceCache[1].Status.State)
+	})
+
+	t.Run("success: instance being deleted concurrently is not overwritten", func(t *testing.T) {
+		// Reset states to Deallocating
+		for i := range asg.instanceCache {
+			asg.instanceCache[i].Status.State = cloudprovider.InstanceDeallocating
+		}
+		// Simulate a concurrent DeleteInstances having set instance 2 to Deleting
+		asg.instanceCache[2].Status.State = cloudprovider.InstanceDeleting
+
+		asg.instanceMutex.Lock()
+		asg.lastInstanceRefresh = time.Now()
+		asg.instanceMutex.Unlock()
+
+		poller := newFakeDeallocatePoller(&fakeSuccessHandler[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]{})
+		asg.waitForDeallocateInstances(poller, instanceRefs, []*string{})
+
+		// Instance 0 and 1 should transition to Deallocated
+		assert.Equal(t, cloudprovider.InstanceDeallocated, asg.instanceCache[0].Status.State)
+		assert.Equal(t, cloudprovider.InstanceDeallocated, asg.instanceCache[1].Status.State)
+		// Instance 2 should remain Deleting
+		assert.Equal(t, cloudprovider.InstanceDeleting, asg.instanceCache[2].Status.State)
+	})
+
+	t.Run("failure: deallocate cache is invalidated", func(t *testing.T) {
 		// Reset states to Deallocating
 		for i := range asg.instanceCache {
 			asg.instanceCache[i].Status.State = cloudprovider.InstanceDeallocating

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
@@ -198,6 +198,43 @@ func (scaleSet *ScaleSet) setInstanceStatusByProviderID(providerID string, statu
 	}
 }
 
+// setInstanceStatusIfNotSuperseded sets the status for an instance only if a newer concurrent
+// operation has not already transitioned it to a different state. This prevents async completion
+// goroutines (e.g., waitForDeallocateInstances) from blindly overwriting cache state that was
+// set by a more recent operation (e.g., startInstance).
+//
+// supersedingStates lists the states that indicate a newer operation has taken over — if the
+// instance is currently in any of these states, the update is skipped.
+func (scaleSet *ScaleSet) setInstanceStatusIfNotSuperseded(providerID string, status cloudprovider.InstanceStatus, supersedingStates []cloudprovider.InstanceState) {
+	scaleSet.instanceMutex.Lock()
+	defer scaleSet.instanceMutex.Unlock()
+
+	err := scaleSet.validateInstanceCacheWithoutLock()
+	if err != nil {
+		klog.Errorf("setInstanceStatusIfNotSuperseded: error validating instanceCache for providerID %s for "+
+			"scaleSet: %s, err: %v", providerID, scaleSet.Name, err)
+	}
+
+	for k, instance := range scaleSet.instanceCache {
+		if instance.Id == providerID {
+			if instance.Status != nil {
+				for _, s := range supersedingStates {
+					if instance.Status.State == s {
+						klog.V(3).Infof("setInstanceStatusIfNotSuperseded: skipping state update for %s "+
+							"in scaleSet %s: current state %v was set by a newer operation (target was %v)",
+							providerID, scaleSet.Name, instance.Status.State, status.State)
+						return
+					}
+				}
+			}
+			klog.V(3).Infof("setInstanceStatusIfNotSuperseded: setting instance state for %s for scaleSet "+
+				"%s to %d", instance.Id, scaleSet.Name, status.State)
+			scaleSet.instanceCache[k].Status = &status
+			break
+		}
+	}
+}
+
 // instanceStatusFromVM converts the VM provisioning state to cloudprovider.InstanceStatus.
 // Suggestion: reunify this with instanceStatusFromProvisioningStateAndPowerState() in azure_scale_set.go
 func (scaleSet *ScaleSet) instanceStatusFromVM(vm *armcompute.VirtualMachineScaleSetVM) *cloudprovider.InstanceStatus {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
@@ -349,6 +349,66 @@ func TestSetInstanceStatusByProviderID(t *testing.T) {
 	assert.Equal(t, 1, len(actualInstances))
 }
 
+func TestSetInstanceStatusIfNotSuperseded(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+	scaleSet.scaleDownPolicy = deallocate.Deallocate
+
+	providerID := azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)
+
+	t.Run("updates state when not superseded", func(t *testing.T) {
+		// Instance starts as Deallocated, target is Deallocated — no superseding states match
+		scaleSet.setInstanceStatusIfNotSuperseded(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+			[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		actual, found, err := scaleSet.getInstanceByProviderID(providerID)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, cloudprovider.InstanceDeallocated, actual.Status.State)
+	})
+
+	t.Run("skips update when current state is in superseding list", func(t *testing.T) {
+		// Set instance to Running (simulating concurrent startInstance)
+		scaleSet.setInstanceStatusByProviderID(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning})
+
+		// Try to set to Deallocated — should be skipped because Running is superseding
+		scaleSet.setInstanceStatusIfNotSuperseded(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+			[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		actual, found, err := scaleSet.getInstanceByProviderID(providerID)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, cloudprovider.InstanceRunning, actual.Status.State)
+	})
+
+	t.Run("skips update when current state is Deleting", func(t *testing.T) {
+		scaleSet.setInstanceStatusByProviderID(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting})
+
+		scaleSet.setInstanceStatusIfNotSuperseded(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+			[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		actual, found, err := scaleSet.getInstanceByProviderID(providerID)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, cloudprovider.InstanceDeleting, actual.Status.State)
+	})
+
+	t.Run("updates when current state is not in superseding list", func(t *testing.T) {
+		// Set to Deallocating — not in the superseding list [Running, Deleting]
+		scaleSet.setInstanceStatusByProviderID(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocating})
+
+		scaleSet.setInstanceStatusIfNotSuperseded(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+			[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		actual, found, err := scaleSet.getInstanceByProviderID(providerID)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, cloudprovider.InstanceDeallocated, actual.Status.State)
+	})
+}
+
 // beforeEachNoInstanceCacheResetNeededHelper has 1 instance in the instanceCache with state = deallocated.
 func TestBeforeEachNoInstanceCacheResetNeededHelper(t *testing.T) {
 	ctrl = gomock.NewController(t)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
customer encountered this issue, it recovers from this state but this is a cleaner fix

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
