### PR TITLE
cherrypick: test: make Azure CAS local e2e invocation

### DIFF
--- a/.agents/skills/run-azure-e2e-tests/SKILL.md
+++ b/.agents/skills/run-azure-e2e-tests/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: run-azure-e2e-tests
+description: 'Run Azure CAS end-to-end tests — per-suite execution with focus filtering, background execution, and local/CI workflows. Use when: running e2e tests, debugging test failures, adding new test suites.'
+---
+
+# E2E Tests for Azure CAS
+
+## Test Structure
+
+```
+cluster-autoscaler/cloudprovider/azure/test/
+├── suites/
+│   └── scaleup/             # Scale-up/down test
+│       └── suite_test.go
+├── pkg/
+│   └── environment/         # Shared Environment struct + helpers
+│       └── environment.go
+├── Makefile                  # Local + CI targets
+└── go.mod
+```
+
+## Local Developer Workflow
+
+From `cluster-autoscaler/cloudprovider/azure/test/`:
+
+### First-time setup
+
+```bash
+az login
+make setup-cluster      # Creates AKS + ACR + workload identity (~5 min)
+make deploy-local       # Builds + deploys CAS via skaffold (~1 min)
+```
+
+### Running tests
+
+```bash
+export AZURE_SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+export AZURE_RESOURCE_GROUP="MC_..."  # Node resource group (printed by setup-cluster)
+
+make e2etests                         # Run all suites
+make e2etests TEST_SUITE=scaleup      # Run single suite
+make e2etests FOCUS="scales up"       # Focus filter
+```
+
+### After code changes
+
+```bash
+make deploy-local       # Rebuild + redeploy CAS
+make e2etests TEST_SUITE=scaleup
+```
+
+### Utility commands
+
+- `make list-suites` — list available test suites
+- `make validate-env` — check required env vars
+- `make deploy-local-dev` — skaffold watch mode (auto-redeploy on changes)
+
+### Background execution (survives VPN drops)
+
+```bash
+nohup make e2etests TEST_SUITE=scaleup > e2e.log 2>&1 &
+tail -f e2e.log
+```
+
+## CI (Prow)
+
+`make test-e2e` builds the CAS image and deploys via Helm (inside BeforeSuite), using cluster info from CAPZ. The Helm deploy is triggered by `-cas-image-repository` and `-cas-image-tag` flags — when absent (local path), Helm is skipped.
+
+## Monitoring
+
+- **Logs**: `tail -f e2e.log`
+- **Cluster**: `kubectl get nodes,pods -w`
+- **Events**: `kubectl get events -A --field-selector source=cluster-autoscaler --watch`
+- **VMSS**: `az vmss list -g $AZURE_RESOURCE_GROUP -o table`
+- **CAS logs**: `kubectl logs -n kube-system deploy/cluster-autoscaler -f`
+
+## Adding a New Test Suite
+
+1. Create `test/suites/<name>/suite_test.go`
+2. Import `pkg/environment` for shared helpers
+3. Register `-resource-group` flag in `init()`
+4. Create `Environment` in `BeforeSuite`, call `EnsureHelmRelease(...)` for CI compatibility
+5. Run: `make e2etests TEST_SUITE=<name>`

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,52 @@
+{
+	"name": "Azure CAS Dev",
+	"image": "mcr.microsoft.com/devcontainers/go:1.25",
+	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/azure-cli:1": {},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"helm": "latest",
+			"minikube": "none"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/rio/features/skaffold:2": {}
+	},
+
+	"onCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends libseccomp-dev",
+
+	"postCreateCommand": {
+		"download cluster-autoscaler modules": "cd cluster-autoscaler && go mod download",
+		"download vertical-pod-autoscaler modules": "cd vertical-pod-autoscaler && go mod download",
+		"install verify tools": "hack/install-verify-tools.sh",
+		"install kind": "go install sigs.k8s.io/kind@latest",
+		"install ko": "go install github.com/google/ko@latest",
+		"install yq": "go install github.com/mikefarah/yq/v4@latest",
+		"disable skaffold metrics": "skaffold config set --global collect-metrics false"
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go",
+				"ms-kubernetes-tools.vscode-kubernetes-tools",
+				"ms-kubernetes-tools.vscode-aks-tools",
+				"ms-azuretools.vscode-bicep",
+				"GitHub.vscode-pull-request-github",
+				"GitHub.copilot-chat"
+			],
+			"settings": {
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go",
+				"go.testFlags": ["-race", "-count=1"],
+				"go.lintTool": "golangci-lint",
+				"go.lintOnSave": "workspace",
+				"chat.useAgentSkills": true
+			}
+		}
+	},
+
+	"remoteUser": "vscode"
+}

--- a/cluster-autoscaler/cloudprovider/azure/examples/dev/aks-dev-deploy.sh
+++ b/cluster-autoscaler/cloudprovider/azure/examples/dev/aks-dev-deploy.sh
@@ -25,8 +25,13 @@ set -euo pipefail
 
 # assumed logged in (az login) and subscription set (az account set --subscription ...)
 
-# set resource group and ACR name (preferably unique)
-RG=${CODESPACE_NAME:-cluster-autoscaler-test}
+# Require AZURE_RESOURCE_GROUP or derive from CODESPACE_NAME (devcontainer).
+: "${AZURE_RESOURCE_GROUP:=${CODESPACE_NAME:-}}"
+if [[ -z "${AZURE_RESOURCE_GROUP}" ]]; then
+    echo "ERROR: AZURE_RESOURCE_GROUP must be set (or run inside a Codespace/devcontainer where CODESPACE_NAME is set)." >&2
+    exit 1
+fi
+RG="${AZURE_RESOURCE_GROUP}"
 ACR_NAME=$(echo "$RG" | tr -d -) # remove hyphens
 az group create --name "${RG}" --location westus3 --output none
 
@@ -68,6 +73,27 @@ export TENANT_ID_B64 RESOURCE_GROUP_MC_B64 VMSS_NAME CAS_UAI_CLIENTID SUBSCRIPTI
 yq '(.. | select(tag == "!!str")) |= envsubst(nu)' \
     cluster-autoscaler-vmss-wi-dynamic.yaml.tpl > \
     cluster-autoscaler-vmss-wi-dynamic.yaml
+
+# create the dynamic node group config (required by the AKS fork)
+kubectl apply -f - <<SETTINGS
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: autoscaler-settings
+  namespace: kube-system
+data:
+  settings.json: |
+    {
+      "nodeGroups": [
+        {
+          "name": "${VMSS_NAME}",
+          "minSize": 1,
+          "maxSize": 10,
+          "scaleDownPolicy": "Delete"
+        }
+      ]
+    }
+SETTINGS
 
 # skaffold dev/run/debug
 

--- a/cluster-autoscaler/cloudprovider/azure/examples/dev/cluster-autoscaler-vmss-wi-dynamic.yaml.tpl
+++ b/cluster-autoscaler/cloudprovider/azure/examples/dev/cluster-autoscaler-vmss-wi-dynamic.yaml.tpl
@@ -158,6 +158,11 @@ spec:
             - --logtostderr=true
             - --cloud-provider=azure
             - --skip-nodes-with-local-storage=false
+            - --skip-nodes-with-system-pods=false
+            - --scale-down-delay-after-add=10s
+            - --scale-down-unneeded-time=10s
+            - --scale-down-candidates-pool-ratio=1.0
+            - --unremovable-node-recheck-timeout=10s
             - --nodes=1:10:${VMSS_NAME}
           env:
             - name: ARM_SUBSCRIPTION_ID
@@ -193,6 +198,9 @@ spec:
             - mountPath: /etc/ssl/certs/ca-certificates.crt
               name: ssl-certs
               readOnly: true
+            - mountPath: /opt/conf/autoscaler
+              name: autoscaler-settings
+              readOnly: true
       # use system nodepool only
       affinity:
         nodeAffinity:
@@ -208,3 +216,6 @@ spec:
             path: /etc/ssl/certs/ca-certificates.crt
             type: ""
           name: ssl-certs
+        - configMap:
+            name: autoscaler-settings
+          name: autoscaler-settings

--- a/cluster-autoscaler/cloudprovider/azure/test/Makefile
+++ b/cluster-autoscaler/cloudprovider/azure/test/Makefile
@@ -64,12 +64,14 @@ help: ## Display help
 
 .PHONY: setup-cluster
 setup-cluster: ## Create AKS cluster + ACR + workload identity for e2e testing
+	@echo "-- creating cluster --"
 	cd $(DEV_DIR) && bash ./aks-dev-deploy.sh
 
 ##@ Build & Deploy
 
 .PHONY: deploy-local
 deploy-local: ## Build CAS and deploy to cluster via skaffold
+	@echo "-- deploying CAS to cluster --"
 	cd $(CAS_ROOT) && skaffold run --filename cloudprovider/azure/examples/dev/skaffold.yaml
 
 .PHONY: deploy-local-dev
@@ -80,6 +82,7 @@ deploy-local-dev: ## Build + deploy CAS in watch mode (auto-redeploy on changes)
 
 .PHONY: e2etests
 e2etests: ## Run e2e tests (CAS must already be deployed)
+	@echo "-- running e2e tests --"
 	go run github.com/onsi/ginkgo/v2/ginkgo \
 		--tags e2e \
 		-v --trace \

--- a/cluster-autoscaler/cloudprovider/azure/test/pkg/environment/environment.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/pkg/environment/environment.go
@@ -74,11 +74,23 @@ type Environment struct {
 
 // NewEnvironment creates a fully initialized Environment.
 func NewEnvironment(resourceGroup string, helm *HelmConfig) *Environment {
+	Expect(resourceGroup).NotTo(BeEmpty(), "resource-group flag is required")
+
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	Expect(subscriptionID).NotTo(BeEmpty(), "AZURE_SUBSCRIPTION_ID environment variable is required")
+
+	tenantID := os.Getenv("AZURE_TENANT_ID")
+	if helm.IsEnabled() {
+		Expect(tenantID).NotTo(BeEmpty(), "AZURE_TENANT_ID is required when Helm deployment is enabled")
+		Expect(helm.ClusterName).NotTo(BeEmpty(), "cluster-name flag is required when Helm deployment is enabled")
+		Expect(helm.ClientID).NotTo(BeEmpty(), "client-id flag is required when Helm deployment is enabled")
+	}
+
 	env := &Environment{
 		Ctx:            context.Background(),
 		ResourceGroup:  resourceGroup,
-		SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
-		TenantID:       os.Getenv("AZURE_TENANT_ID"),
+		SubscriptionID: subscriptionID,
+		TenantID:       tenantID,
 		Helm:           helm,
 	}
 
@@ -192,17 +204,17 @@ func (env *Environment) AllVMSSStable(g Gomega) {
 
 	nodes := &corev1.NodeList{}
 	g.Expect(env.K8s.List(env.Ctx, nodes)).To(Succeed())
-	g.Expect(nodes.Items).To(SatisfyAll(
-		HaveLen(expectedNodes),
-		ContainElements(Satisfy(func(node corev1.Node) bool {
-			for _, cond := range node.Status.Conditions {
-				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-					return true
-				}
+	g.Expect(nodes.Items).To(HaveLen(expectedNodes))
+	for _, node := range nodes.Items {
+		ready := false
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				ready = true
+				break
 			}
-			return false
-		})),
-	))
+		}
+		g.Expect(ready).To(BeTrue(), "node %s is not Ready", node.Name)
+	}
 }
 
 // --- K8s helpers ---

--- a/cluster-autoscaler/cloudprovider/azure/test/suites/scaleup/suite_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/suites/scaleup/suite_test.go
@@ -70,7 +70,6 @@ func helmValuesForFastScaleDown() map[string]interface{} {
 		},
 	}
 }
-
 func init() {
 	flag.StringVar(&resourceGroup, "resource-group", "", "resource group containing cluster-autoscaler-managed resources (the MC_ node resource group)")
 	flag.StringVar(&clusterName, "cluster-name", "", "Cluster API Cluster name (CI only)")


### PR DESCRIPTION
## Summary
Cherry-picks commit `45a885c45c6535de9b0f57abc9ac255e7226b8e2` onto `master-azure`.

This brings over the Azure CAS local e2e workflow changes, including the local/CI e2e layout updates, developer devcontainer, and the local deployment script/template adjustments that make the 1.35 flow work.

## Conflict Resolution
- `cluster-autoscaler/cloudprovider/azure/test/Makefile`: kept the new breadcrumb `@echo` lines for `setup-cluster`, `deploy-local`, and `e2etests`.
- `cluster-autoscaler/cloudprovider/azure/test/pkg/environment/environment.go`: kept the cherry-picked input validation in `NewEnvironment` and the stricter `AllVMSSStable` readiness check that verifies every node is Ready.
- `cluster-autoscaler/cloudprovider/azure/test/suites/scaleup/suite_test.go`: resolved a marker-only add/add conflict with no intended behavior change.

## Validation
- `cd cluster-autoscaler/cloudprovider/azure/test && GOTOOLCHAIN=auto go test -tags e2e -run TestDoesNotExist ./...`

## Source
- Cherry-picked from `45a885c45c6535de9b0f57abc9ac255e7226b8e2`
