### PR TITLE
[1.35] fix: enable backoff for deallocate-mode failed-to-start VMs (#48)

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
@@ -237,14 +237,27 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *armcompute.VirtualMachineScal
 		status.State = cloudprovider.InstanceRunning
 
 		klog.V(3).Infof("VM %s reports failed provisioning state with power state: %s, scale down mode: %s, eligible for fast delete: %s", ptr.Deref(vm.ID, ""), powerState, scaleSet.scaleDownPolicy, strconv.FormatBool(scaleSet.enableFastDeleteOnFailedProvisioning))
-		if scaleSet.scaleDownPolicy != deallocate.Deallocate && scaleSet.enableFastDeleteOnFailedProvisioning {
-			// Provisioning can fail both during instance creation or after the instance is running.
+		if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+			// Deallocate mode: detect failed-to-start VMs.
+			if !isRunningVmPowerState(powerState) {
+				// VM failed to start — remains deallocated or stopped.
+				// Signal as creation error to trigger backoff via handleInstanceCreationErrors.
+				// Failed VMs will be deleted by deleteCreatedNodesWithErrors.
+				status.State = cloudprovider.InstanceCreating
+				status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "start-deallocated-failed",
+					ErrorMessage: "Failed to start deallocated VM",
+				}
+			}
+			// Running power state: VM started but may have extension errors.
+			// CSE error check below (enableDetailedCSEMessage) handles this case.
+		} else if scaleSet.enableFastDeleteOnFailedProvisioning {
+			// Delete mode: existing fast-delete path for failed provisioning.
 			// Per https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing#provisioning-states,
 			// ProvisioningState represents the most recent provisioning state, therefore only report
 			// InstanceCreating errors when the power state indicates the instance has not yet started running
 			if !isRunningVmPowerState(powerState) {
-				// This fast deletion relies on the fact that InstanceCreating + ErrorInfo will subsequently trigger a deletion.
-				// Could be revisited to rely on something more stable/explicit.
 				status.State = cloudprovider.InstanceCreating
 				status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
 					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
@@ -254,9 +267,6 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *armcompute.VirtualMachineScal
 			} else {
 				status.State = cloudprovider.InstanceRunning
 			}
-		} else if scaleSet.scaleDownPolicy == deallocate.Deallocate {
-			// Current(?) deallocate mode design handles InstanceFailed and InstanceRunning differently.
-			status.State = cloudprovider.InstanceFailed
 		}
 	default:
 		status.State = cloudprovider.InstanceRunning

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
@@ -235,14 +235,15 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *armcompute.VirtualMachineScal
 		status.State = cloudprovider.InstanceCreating
 	case VMProvisioningStateFailed:
 		status.State = cloudprovider.InstanceRunning
-
 		klog.V(3).Infof("VM %s reports failed provisioning state with power state: %s, scale down mode: %s, eligible for fast delete: %s", ptr.Deref(vm.ID, ""), powerState, scaleSet.scaleDownPolicy, strconv.FormatBool(scaleSet.enableFastDeleteOnFailedProvisioning))
 		if scaleSet.scaleDownPolicy == deallocate.Deallocate {
 			// Deallocate mode: detect failed-to-start VMs.
 			if !isRunningVmPowerState(powerState) {
 				// VM failed to start — remains deallocated or stopped.
 				// Signal as creation error to trigger backoff via handleInstanceCreationErrors.
-				// Failed VMs will be deleted by deleteCreatedNodesWithErrors.
+				// Failed VMs will be cleaned up by deleteCreatedNodesWithErrors, which for
+				// deallocate mode calls ForceDeleteNodes → deallocateInstances (returning
+				// the VM to a clean deallocated state for the next scale-up after backoff).
 				status.State = cloudprovider.InstanceCreating
 				status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
 					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_deallocate_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_deallocate_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+)
+
+// TestInstanceStatusFromVMErrorCodeByScaleDownModeSelfHosted verifies error codes
+// for self-hosted clusters with enableFastDeleteOnFailedProvisioning=false.
+// In this case, only deallocate mode generates error codes; delete mode returns InstanceRunning.
+func TestInstanceStatusFromVMErrorCodeByScaleDownModeSelfHosted(t *testing.T) {
+	tests := map[string]struct {
+		scaleDownPolicy   deallocate.ScaleDownPolicy
+		expectedState     cloudprovider.InstanceState
+		expectedErrorCode string
+	}{
+		"deallocate mode still gets start-deallocated-failed without fast delete": {
+			scaleDownPolicy:   deallocate.Deallocate,
+			expectedState:     cloudprovider.InstanceCreating,
+			expectedErrorCode: "start-deallocated-failed",
+		},
+		"delete mode falls back to InstanceRunning without fast delete": {
+			scaleDownPolicy:   deallocate.Delete,
+			expectedState:     cloudprovider.InstanceRunning,
+			expectedErrorCode: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			provider := newTestProvider(t)
+			scaleSet := &ScaleSet{
+				azureRef:                             azureRef{Name: "testScaleSet"},
+				manager:                              provider.azureManager,
+				minSize:                              1,
+				maxSize:                              5,
+				enableFastDeleteOnFailedProvisioning: false, // self-hosted: fast delete disabled
+				scaleDownPolicy:                      tt.scaleDownPolicy,
+			}
+
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopped)
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, tt.expectedState, status.State)
+			if tt.expectedErrorCode != "" {
+				assert.NotNil(t, status.ErrorInfo)
+				assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+				assert.Equal(t, tt.expectedErrorCode, status.ErrorInfo.ErrorCode)
+			} else {
+				// In delete mode with fast delete off, no error info.
+				assert.Nil(t, status.ErrorInfo)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
@@ -202,11 +202,12 @@ func newTestScaleSetDeallocateModeWithFastDelete(manager *AzureManager, name str
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager:           manager,
-		minSize:           1,
-		maxSize:           5,
-		enableForceDelete: manager.config.EnableForceDelete,
-		scaleDownPolicy:   deallocate.Deallocate,
+		manager:                              manager,
+		minSize:                              1,
+		maxSize:                              5,
+		enableForceDelete:                    manager.config.EnableForceDelete,
+		enableFastDeleteOnFailedProvisioning: true,
+		scaleDownPolicy:                      deallocate.Deallocate,
 	}
 }
 
@@ -294,9 +295,11 @@ func TestGetInstancesByState(t *testing.T) {
 	scaleSet.scaleDownPolicy = deallocate.Deallocate
 
 	// t2 - cache is stale - instance with given state exists in the instanceCache
-	actualInstances, err = scaleSet.getInstancesByState(cloudprovider.InstanceFailed)
+	// VM[0] has ProvisioningState=Failed + no InstanceView (defaults to running power state)
+	// In deallocate mode, running VMs with failed provisioning are treated as InstanceRunning
+	actualInstances, err = scaleSet.getInstancesByState(cloudprovider.InstanceRunning)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(actualInstances)) // there should be only one instance with failed State
+	assert.Equal(t, 1, len(actualInstances)) // there should be only one instance with running state (was InstanceFailed before fix)
 	assert.Equal(t, expectedInstanceCache[0].Id, actualInstances[0].Id)
 	assert.Equal(t, expectedInstanceCache[0].Status.State, actualInstances[0].Status.State)
 
@@ -342,11 +345,11 @@ func TestSetInstanceStatusByProviderID(t *testing.T) {
 	// t2 - cache is stale - expectInstanceCache update, set for providerID=2 will not be added to the instanceCache because
 	// it doesn't exist in the cache. GetScaleSetVms() will have not introduced instance with providerID=2
 	providerID = azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)
-	status = cloudprovider.InstanceStatus{State: cloudprovider.InstanceFailed}
+	status = cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting}
 	scaleSet.setInstanceStatusByProviderID(providerID, status) // it will not set for providerID=2 as it is not already present in the cache
-	actualInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceFailed)
+	actualInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceDeleting)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(actualInstances))
+	assert.Equal(t, 0, len(actualInstances))
 }
 
 // beforeEachNoInstanceCacheResetNeededHelper has 1 instance in the instanceCache with state = deallocated.
@@ -394,7 +397,7 @@ func TestBeforeEachInstanceCacheResetNeededHelper(t *testing.T) {
 	}
 	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(
 		expectedVMSSVMs, nil)
-	expectedStates = []cloudprovider.InstanceState{cloudprovider.InstanceFailed, cloudprovider.InstanceDeallocated}
+	expectedStates = []cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeallocated}
 	expectedInstanceCache = testGetInstanceCacheWithStates(t, expectedVMSSVMs, expectedStates)
 }
 
@@ -403,6 +406,7 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 
 	scaleSet.scaleDownPolicy = deallocate.Deallocate
 	// Disabled EnableFastDelete, deallocate mode, running power state
+	// Running VMs in deallocate mode default to InstanceRunning (CSE error check handles broken VMs)
 	vm := &armcompute.VirtualMachineScaleSetVM{
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To(string(armcompute.GalleryProvisioningStateFailed)),
@@ -415,9 +419,10 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status := scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 
 	// Enabled EnableFastDelete, deallocate mode, running power state
+	// Running VMs still get InstanceRunning — fast-delete doesn't apply in deallocate mode for running VMs
 	scaleSet.enableFastDeleteOnFailedProvisioning = true
 	vm = &armcompute.VirtualMachineScaleSetVM{
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
@@ -431,10 +436,11 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status = scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 	scaleSet.enableFastDeleteOnFailedProvisioning = false
 
 	// Enabled EnableFastDelete, deallocate mode, not running power state
+	// Non-running VMs in deallocate mode trigger backoff (InstanceCreating + ErrorInfo)
 	scaleSet.enableFastDeleteOnFailedProvisioning = true
 	vm = &armcompute.VirtualMachineScaleSetVM{
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
@@ -448,7 +454,10 @@ func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) 
 	}
 	status = scaleSet.instanceStatusFromVM(vm)
 	assert.NotNil(t, status)
-	assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotNil(t, status.ErrorInfo)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+	assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 	scaleSet.enableFastDeleteOnFailedProvisioning = false
 
 	scaleSet.scaleDownPolicy = deallocate.Delete
@@ -540,6 +549,77 @@ func TestInstanceStatusFromVMEnableFastDeleteOnCSEFailure(t *testing.T) {
 	scaleSet.enableFastDeleteOnFailedProvisioning = false
 }
 
+func TestInstanceStatusFromVMDeallocateModeCSEFailure(t *testing.T) {
+	// Deallocate mode + running VM + Custom Script Extension (CSE) error: the CSE check should override
+	// InstanceRunning with InstanceCreating + OtherErrorClass. This is the main detection path for VMs that
+	// started but have broken extensions (Gap 2 from the tail-side error handling design).
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSetDeallocateModeWithFastDelete(provider.azureManager, "testScaleSet")
+	scaleSet.enableDetailedCSEMessage = true
+
+	vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateRunning)
+	vm.Properties.InstanceView.Extensions = []*armcompute.VirtualMachineExtensionInstanceView{
+		{
+			Name: ptr.To(vmssCSEExtensionName),
+			Statuses: []*armcompute.InstanceViewStatus{
+				{
+					Level:   ptr.To(armcompute.StatusLevelTypesError),
+					Code:    ptr.To(vmssExtensionProvisioningFailed),
+					Message: ptr.To("Custom Script Extension failed to provision"),
+				},
+			},
+		},
+	}
+
+	status := scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotNil(t, status.ErrorInfo)
+	assert.Equal(t, cloudprovider.OtherErrorClass, status.ErrorInfo.ErrorClass)
+	assert.Equal(t, vmssExtensionProvisioningFailed, status.ErrorInfo.ErrorCode)
+}
+
+func TestInstanceStatusFromVMErrorCodeByScaleDownMode(t *testing.T) {
+	// Verify that deallocate mode and delete mode get distinct error codes
+	// under identical conditions (Failed + non-running + enableFastDelete).
+	tests := map[string]struct {
+		scaleDownPolicy   deallocate.ScaleDownPolicy
+		expectedErrorCode string
+	}{
+		"deallocate mode gets start-deallocated-failed": {
+			scaleDownPolicy:   deallocate.Deallocate,
+			expectedErrorCode: "start-deallocated-failed",
+		},
+		"delete mode gets provisioning-state-failed": {
+			scaleDownPolicy:   deallocate.Delete,
+			expectedErrorCode: "provisioning-state-failed",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			provider := newTestProvider(t)
+			scaleSet := &ScaleSet{
+				azureRef:                             azureRef{Name: "testScaleSet"},
+				manager:                              provider.azureManager,
+				minSize:                              1,
+				maxSize:                              5,
+				enableFastDeleteOnFailedProvisioning: true,
+				scaleDownPolicy:                      tt.scaleDownPolicy,
+			}
+
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopped)
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+			assert.Equal(t, tt.expectedErrorCode, status.ErrorInfo.ErrorCode)
+		})
+	}
+}
+
 func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 	t.Run("fast delete enablement = false", func(t *testing.T) {
 		provider := newTestProvider(t)
@@ -547,56 +627,54 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 
 		t.Run("provisioning state = failed, power state = starting", func(t *testing.T) {
 			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStarting)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Without enableFastDeleteOnFailedProvisioning, all failed VMs default to InstanceRunning
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
 			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateRunning)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
 			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopping)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopping is not a running power state — triggers backoff even without enableFastDelete
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
 			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopped)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
 			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateDeallocated)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
 			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateUnknown)
-
 			status := scaleSet.instanceStatusFromVM(vm)
-
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 	})
 
@@ -610,7 +688,8 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Starting is a running power state — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
@@ -619,7 +698,8 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Running VM with failed provisioning — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
@@ -628,7 +708,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopping is not a running power state — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
@@ -637,7 +720,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Stopped is not running — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
@@ -646,7 +732,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Deallocated VM that failed to start — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 
 		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
@@ -655,7 +744,10 @@ func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
 			status := scaleSet.instanceStatusFromVM(vm)
 
 			assert.NotNil(t, status)
-			assert.Equal(t, cloudprovider.InstanceFailed, status.State)
+			// Unknown power state (not running) — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 	})
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -27,6 +27,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachineclient/mock_virtualmachineclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetclient/mock_virtualmachinescalesetclient"
@@ -1512,4 +1513,93 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 			assert.NotNil(t, status.ErrorInfo)
 		})
 	})
+}
+
+// TestForceDeleteNodesDeallocateMode verifies that ForceDeleteNodes routes to
+// deallocateInstances (BeginDeallocate) for deallocate-mode groups, and to
+// DeleteInstances (BeginDeleteInstances) for delete-mode groups.
+func TestForceDeleteNodesDeallocateMode(t *testing.T) {
+	tests := map[string]struct {
+		scaleDownPolicy       deallocate.ScaleDownPolicy
+		expectDeallocate      bool
+		expectDeleteInstances bool
+	}{
+		"deallocate mode routes to deallocateInstances": {
+			scaleDownPolicy:       deallocate.Deallocate,
+			expectDeallocate:      true,
+			expectDeleteInstances: false,
+		},
+		"delete mode routes to DeleteInstances": {
+			scaleDownPolicy:       deallocate.Delete,
+			expectDeallocate:      false,
+			expectDeleteInstances: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			vmssName := "test-asg"
+			var vmssCapacity int64 = 3
+
+			expectedVMSSVMs := newTestVMSSVMList(3)
+			expectedVMs := newTestVMList(3)
+
+			manager := newTestAzureManager(t)
+			manager.config.EnableForceDelete = true
+			expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", armcompute.OrchestrationModeUniform)
+
+			mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+			mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+			if tc.expectDeallocate {
+				mockDeleteClient.EXPECT().BeginDeallocate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+			}
+			if tc.expectDeleteInstances {
+				mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+			}
+			manager.azClient.vmssClientForDelete = mockDeleteClient
+
+			mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+			mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+
+			err := manager.forceRefresh()
+			assert.NoError(t, err)
+
+			resourceLimiter := cloudprovider.NewResourceLimiter(
+				map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+				map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+			provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+			assert.NoError(t, err)
+
+			scaleSet := newTestScaleSet(manager, vmssName)
+			scaleSet.scaleDownPolicy = tc.scaleDownPolicy
+			registered := manager.RegisterNodeGroup(scaleSet)
+			manager.explicitlyConfigured[vmssName] = true
+			assert.True(t, registered)
+
+			err = manager.forceRefresh()
+			assert.NoError(t, err)
+
+			ss, ok := provider.NodeGroups()[0].(*ScaleSet)
+			assert.True(t, ok)
+			ss.scaleDownPolicy = tc.scaleDownPolicy
+
+			nodesToDelete := []*apiv1.Node{
+				newApiNode(armcompute.OrchestrationModeUniform, 0),
+			}
+
+			err = ss.ForceDeleteNodes(nodesToDelete)
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/cluster-autoscaler/clusterstate/clusterstate_deallocate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_deallocate_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterstate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	mockprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/mocks"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	"k8s.io/client-go/kubernetes/fake"
+	kube_record "k8s.io/client-go/tools/record"
+)
+
+// TestHandleInstanceCreationErrorsStartDeallocatedFailed verifies that deallocated VMs
+// that fail to start trigger backoff with the expected Azure-specific error code.
+func TestHandleInstanceCreationErrorsStartDeallocatedFailed(t *testing.T) {
+	now := time.Now()
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	mockedNodeGroup := &mockprovider.NodeGroup{}
+	mockedNodeGroup.On("Id").Return("deallocate-pool")
+	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{
+		{
+			Id: "vm1",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "start-deallocated-failed",
+					ErrorMessage: "Failed to start deallocated VM",
+				},
+			},
+		},
+		{
+			Id: "vm2",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "start-deallocated-failed",
+					ErrorMessage: "Failed to start deallocated VM",
+				},
+			},
+		},
+	}, nil)
+	mockedNodeGroup.On("Autoprovisioned").Return(false)
+	mockedNodeGroup.On("TargetSize").Return(2, nil)
+	node := BuildTestNode("deallocate-pool_1", 1000, 1000)
+	mockedNodeGroup.On("TemplateNodeInfo").Return(framework.NewTestNodeInfo(node), nil)
+	mockedNodeGroup.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
+	provider.InsertNodeGroup(mockedNodeGroup)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	mockMetrics := &mockMetrics{}
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+	clusterstate.RegisterScaleUp(mockedNodeGroup, 2, now)
+
+	// UpdateNodes will trigger handleInstanceCreationErrors.
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
+
+	// Verify metrics were recorded.
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("start-deallocated-failed"), "", "")
+
+	// Verify the node group is in backoff with the correct error code.
+	safety := clusterstate.NodeGroupScaleUpSafety(mockedNodeGroup, now)
+	assert.False(t, safety.SafeToScale, "node group should not be safe to scale")
+	assert.True(t, safety.BackoffStatus.IsBackedOff, "node group should be backed off after start-deallocated-failed")
+	assert.Equal(t, "start-deallocated-failed", safety.BackoffStatus.ErrorInfo.ErrorCode)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, safety.BackoffStatus.ErrorInfo.ErrorClass)
+}

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -1683,6 +1683,13 @@ func TestHandleInstanceCreationErrors(t *testing.T) {
 	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
 	assert.NoError(t, err)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "")
+
+	// Verify the node group is in backoff with the correct error code
+	safety := clusterstate.NodeGroupScaleUpSafety(mockedNodeGroup, now)
+	assert.False(t, safety.SafeToScale, "node group should not be safe to scale")
+	assert.True(t, safety.BackoffStatus.IsBackedOff, "node group should be backed off")
+	assert.Equal(t, "RESOURCE_POOL_EXHAUSTED", safety.BackoffStatus.ErrorInfo.ErrorCode)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, safety.BackoffStatus.ErrorInfo.ErrorClass)
 }
 
 type mockMetrics struct {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
cherry-pick of https://github.com/Azure/autoscaler/pull/48

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
