### PR TITLE
fix(azure): invalidate instance cache after ETag refresh (deallocate mode)

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -647,6 +647,14 @@ func (scaleSet *ScaleSet) retryCreateOrUpdateWithFreshETag(ctx context.Context, 
 	// Persist the freshly-fetched VMSS (ETag and capacity) for subsequent operations.
 	scaleSet.manager.azureCache.setScaleSet(scaleSet.Name, fresh)
 
+	// The refreshed VMSS reflects the concurrent writer's change (for example, instances
+	// removed by an out-of-band delete while in deallocate mode). Invalidate the instance
+	// cache so the deallocated/deallocating count consumed by getScaleSetSize is recomputed
+	// from fresh Azure state; otherwise a stale count could be subtracted from the fresh
+	// capacity and yield an incorrect (potentially negative) target size. Callers of this
+	// method hold sizeMutex; invalidateInstanceCache guards the instance cache separately.
+	scaleSet.invalidateInstanceCache()
+
 	// If another writer already grew the VMSS to at least our target, the desired floor
 	// is already met; don't issue a PUT that would shrink it back down. Return the fresh
 	// object (nil poller) so the caller publishes its actual capacity, not a stale target.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -2188,6 +2188,70 @@ func TestScaleSetETagRetrySkippedWhenAlreadyAtTarget(t *testing.T) {
 	assert.Equal(t, 1, putCalls, "expected no second PUT when VMSS already at target")
 }
 
+// TestScaleSetETagRetryInvalidatesInstanceCache verifies that after an ETag precondition
+// refresh, the instance cache is invalidated so a stale deallocated/deallocating count is
+// not reused. In deallocate mode getScaleSetSize subtracts the deallocated instance count
+// (read from the instance cache) from the reported capacity; if a concurrent writer removed
+// instances out-of-band (the case ETag guards), the refreshed VMSS carries fresh capacity
+// but the instance cache would still hold the pre-change count, yielding an incorrect
+// (potentially negative) target size. The refresh must therefore mark the instance cache
+// stale so it is recomputed from fresh Azure state.
+func TestScaleSetETagRetryInvalidatesInstanceCache(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-dealloc-invalidate"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	// CA's cached view: stale ETag, capacity 3.
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name:       ptr.To(vmssName),
+		SKU:        &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+		Etag:       ptr.To(`W/"stale"`),
+	})
+
+	// The refresh GET returns a fresh VMSS already at/above the desired target so the retry
+	// takes the skip path (GET only, no second PUT). The cache invalidation runs regardless.
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name:       ptr.To(vmssName),
+			SKU:        &armcompute.SKU{Capacity: ptr.To[int64](5)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+			Etag:       ptr.To(`W/"fresh"`),
+		}, nil).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	scaleSet := newTestScaleSetDeallocateMode(manager, vmssName)
+	scaleSet.instancesRefreshPeriod = 10 * time.Minute
+	// Mark the instance cache as freshly refreshed so we can observe the invalidation.
+	scaleSet.lastInstanceRefresh = time.Now()
+	assert.True(t, scaleSet.lastInstanceRefresh.Add(scaleSet.instancesRefreshPeriod).After(time.Now()),
+		"precondition: instance cache should start valid")
+
+	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
+	defer cancel()
+
+	fresh, poller, err := scaleSet.retryCreateOrUpdateWithFreshETag(ctx, 4)
+	assert.NoError(t, err)
+	assert.Nil(t, poller, "already-at-target refresh should skip the retry PUT")
+	if assert.NotNil(t, fresh) && assert.NotNil(t, fresh.SKU) && assert.NotNil(t, fresh.SKU.Capacity) {
+		assert.Equal(t, int64(5), *fresh.SKU.Capacity)
+	}
+
+	// The instance cache must now be considered stale, forcing a fresh recompute of the
+	// deallocated/deallocating count on the next getScaleSetSize.
+	assert.False(t, scaleSet.lastInstanceRefresh.Add(scaleSet.instancesRefreshPeriod).After(time.Now()),
+		"ETag refresh should invalidate the instance cache")
+}
+
 // TestScaleSetETagReconcilesConcurrentWriter exercises the core scenario ETag mode is
 // meant to protect: another writer mutates the VMSS between CA's read and its write.
 // Using a mock that enforces optimistic concurrency like the real API, CA's first PUT


### PR DESCRIPTION
## What this PR does

On an ETag precondition failure, `retryCreateOrUpdateWithFreshETag` fetches a fresh VMSS and persists it (capacity + ETag) to the cache, but on the success/skip paths it does not invalidate the **instance** cache.

In deallocate mode, `getScaleSetSize` computes the target as the reported VMSS capacity **minus** the deallocated/deallocating instance count, which is read from the instance cache. ETag mode specifically guards the case where a concurrent writer removed instances out-of-band between CA's read and its write. After the refresh, the cached VMSS reflects the fresh (lower) capacity, but the instance cache can still hold the pre-change deallocated count — so a stale count subtracted from the fresh capacity can yield an incorrect, potentially negative, target size.

This change invalidates the instance cache after persisting the refreshed VMSS, so the deallocated/deallocating count is recomputed from fresh Azure state on the next `getScaleSetSize`.

## Change

- `retryCreateOrUpdateWithFreshETag`: call `invalidateInstanceCache()` after `setScaleSet(fresh)` (covers both the skip and re-PUT paths). Callers hold `sizeMutex`; `invalidateInstanceCache` guards the instance cache with its own mutex.
- Adds `TestScaleSetETagRetryInvalidatesInstanceCache` (deallocate mode): seeds a valid instance cache, drives an ETag refresh, asserts the instance cache is marked stale.

## Validation

- `go build ./cloudprovider/azure/`: passing
- `gofmt -l` (changed files): clean
- `go test --test.short -race ./cloudprovider/azure/`: passing

## Notes

- Scoped to the ETag refresh path only; no behavioral change when ETag is disabled.
- This targets the root cause (stale deallocated count after a refresh). It is intentionally independent of the separate defensive change that guards `getScaleSetSize` against a cached negative size, so the two can be evaluated on their own.
