### PR TITLE
[1.35] deallocate-mode ETag + negative-size hardening

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -1023,13 +1023,21 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 
 	if !scaleSet.manager.config.StrictCacheUpdates {
 		// Proactively decrement scale set size so that we don't
-		// go below minimum node count if cache data is stale
-		// only do it for non-unregistered nodes
+		// go below minimum node count if cache data is stale.
+		// If the cached size can't represent the delete batch,
+		// mark it stale instead of publishing a negative size.
+		// Only do it for non-unregistered nodes.
 
 		if !hasUnregisteredNodes {
+			deleteCount := int64(len(instanceIDs))
 			scaleSet.sizeMutex.Lock()
-			scaleSet.curSize -= int64(len(instanceIDs))
-			scaleSet.lastSizeRefresh = time.Now()
+			if scaleSet.curSize < deleteCount {
+				klog.Warningf("VMSS: %s, cached size %d is smaller than instances to delete %d, invalidating size cache instead of decrementing", scaleSet.Name, scaleSet.curSize, deleteCount)
+				scaleSet.lastSizeRefresh = time.Time{}
+			} else {
+				scaleSet.curSize -= deleteCount
+				scaleSet.lastSizeRefresh = time.Now()
+			}
 			scaleSet.sizeMutex.Unlock()
 		}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -652,6 +652,14 @@ func (scaleSet *ScaleSet) retryCreateOrUpdateWithFreshETag(ctx context.Context, 
 	// Persist the freshly-fetched VMSS (ETag and capacity) for subsequent operations.
 	scaleSet.manager.azureCache.setScaleSet(scaleSet.Name, fresh)
 
+	// The refreshed VMSS reflects the concurrent writer's change (for example, instances
+	// removed by an out-of-band delete while in deallocate mode). Invalidate the instance
+	// cache so the deallocated/deallocating count consumed by getScaleSetSize is recomputed
+	// from fresh Azure state; otherwise a stale count could be subtracted from the fresh
+	// capacity and yield an incorrect (potentially negative) target size. Callers of this
+	// method hold sizeMutex; invalidateInstanceCache guards the instance cache separately.
+	scaleSet.invalidateInstanceCache()
+
 	// If another writer already grew the VMSS to at least our target, the desired floor
 	// is already met; don't issue a PUT that would shrink it back down. Return the fresh
 	// object (nil poller) so the caller publishes its actual capacity, not a stale target.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -303,6 +303,16 @@ func (scaleSet *ScaleSet) getScaleSetSize() (int64, error) {
 			return -1, err
 		}
 		size -= int64(totalDeallocationInstances)
+		if size < 0 {
+			// A negative deallocate-adjusted size means the deallocated/deallocating count
+			// exceeds the reported capacity, which is only possible when the caches are
+			// inconsistent (e.g. instances removed out-of-band). Surface it as an error
+			// rather than publishing a negative target, mirroring the size == -1 guard above.
+			err := fmt.Errorf("failed to get scale set size for %s: capacity minus %d deallocated/deallocating instances is negative (%d); instance cache likely stale",
+				scaleSet.Name, totalDeallocationInstances, size)
+			klog.V(3).Infof("getScaleSetSize: negative deallocate-adjusted size (actual err:%v)", err)
+			return -1, err
+		}
 		klog.V(3).Infof("Found: %d instances in deallocated state, returning target size: %d for scaleSet %s",
 			totalDeallocationInstances, size, scaleSet.Name)
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -1069,9 +1069,8 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 		}
 		return
 	}
-	if !scaleSet.manager.config.StrictCacheUpdates {
-		scaleSet.invalidateInstanceCache()
-	}
+	scaleSet.invalidateInstanceCache()
+	scaleSet.invalidateLastSizeRefreshWithLock()
 	klog.Errorf("PollUntilDone for DeleteInstances(%v) for %s failed with error: %v", requiredIds.InstanceIDs, scaleSet.Name, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -285,9 +285,14 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 func (scaleSet *ScaleSet) getScaleSetSize() (int64, error) {
 	// First, get the current size of the ScaleSet
 	size, getVMSSError := scaleSet.getCurSize()
-	if size == -1 || getVMSSError != nil {
-		klog.V(3).Infof("getScaleSetSize: either size is -1 (actual: %d) or error exists (actual err:%v)", size, getVMSSError.error)
+	if getVMSSError != nil {
+		klog.V(3).Infof("getScaleSetSize: error exists (actual err:%v)", getVMSSError.error)
 		return size, getVMSSError.error
+	}
+	if size == -1 {
+		err := fmt.Errorf("failed to get scale set size for %s: cached size is -1 without provider error", scaleSet.Name)
+		klog.V(3).Infof("getScaleSetSize: size is -1 (actual err:%v)", err)
+		return size, err
 	}
 	// If the policy for this ScaleSet is Deallocate, the TargetSize is the capacity reported by VMSS minus the nodes in deallocated and deallocating states
 	if scaleSet.scaleDownPolicy == deallocate.Deallocate {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -255,6 +255,22 @@ func TestScaleSetTargetSize(t *testing.T) {
 	}
 }
 
+func TestScaleSetTargetSizeReturnsErrorForCachedNegativeSize(t *testing.T) {
+	provider := newTestProvider(t)
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	scaleSet := newTestScaleSet(provider.azureManager, testASG)
+	scaleSet.curSize = -1
+	scaleSet.lastSizeRefresh = time.Now()
+	scaleSet.sizeRefreshPeriod = time.Hour
+
+	size, err := scaleSet.TargetSize()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cached size is -1 without provider error")
+	assert.Equal(t, -1, size)
+}
+
 func TestScaleSetIncreaseSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -1139,6 +1139,80 @@ func TestScaleSetDeleteNodes(t *testing.T) {
 	}
 }
 
+func TestScaleSetForceDeleteNodesDoesNotPublishNegativeCachedSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	vmssName := testASG
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+	expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", orchMode)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
+
+	manager := newTestAzureManager(t)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedVMs, nil).AnyTimes()
+	manager.azClient.virtualMachinesClient = mockVMClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	resourceLimiter := cloudprovider.NewResourceLimiter(
+		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+	provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, testASG))
+	manager.explicitlyConfigured[testASG] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+	assert.True(t, ok)
+
+	targetSize, err := scaleSet.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+
+	scaleSet.curSize = 1
+	scaleSet.lastSizeRefresh = time.Now()
+	scaleSet.sizeRefreshPeriod = time.Hour
+
+	nodesToDelete := []*apiv1.Node{
+		newApiNode(orchMode, 0),
+		newApiNode(orchMode, 2),
+	}
+	err = scaleSet.ForceDeleteNodes(nodesToDelete)
+	assert.NoError(t, err)
+
+	scaleSet.sizeMutex.Lock()
+	curSize := scaleSet.curSize
+	lastSizeRefresh := scaleSet.lastSizeRefresh
+	scaleSet.sizeMutex.Unlock()
+	assert.Equal(t, int64(1), curSize)
+	assert.True(t, lastSizeRefresh.IsZero())
+
+	targetSize, err = scaleSet.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+}
+
 func TestScaleSetDeleteNodeUnregistered(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -2145,6 +2146,109 @@ func TestScaleSetETagPreconditionFailureRollsBackCapacity(t *testing.T) {
 	target, err := scaleSet.TargetSize()
 	assert.NoError(t, err)
 	assert.Equal(t, 3, target)
+}
+
+type testPollingHandler[T any] struct {
+	err    error
+	polled bool
+}
+
+func (f *testPollingHandler[T]) Done() bool {
+	return f.polled && f.err == nil
+}
+
+func (f *testPollingHandler[T]) Poll(_ context.Context) (*http.Response, error) {
+	f.polled = true
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, f.err
+}
+
+func (f *testPollingHandler[T]) Result(_ context.Context, _ *T) error {
+	return f.err
+}
+
+func newTestPollerWithError(err error) *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse] {
+	resp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+	}
+	pl := runtime.NewPipeline("test", "v0.0.0", runtime.PipelineOptions{}, nil)
+	poller, pollerErr := runtime.NewPoller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse](resp, pl, &runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]{
+		Handler: &testPollingHandler[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]{err: err},
+	})
+	if pollerErr != nil {
+		panic(pollerErr)
+	}
+	return poller
+}
+
+func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+
+	expectedScaleSets := []*armcompute.VirtualMachineScaleSet{
+		{
+			Name: ptr.To(vmssName),
+			SKU:  &armcompute.SKU{Capacity: ptr.To(vmssCapacity)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+		},
+	}
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+	manager.explicitlyConfigured["test-asg"] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+		InstanceIDs: []*string{ptr.To("0")},
+	}
+
+	for _, strictCacheUpdates := range []bool{false, true} {
+		t.Run(fmt.Sprintf("strict cache updates %t", strictCacheUpdates), func(t *testing.T) {
+			manager.config.StrictCacheUpdates = strictCacheUpdates
+			scaleSet := newTestScaleSet(manager, "test-asg")
+			scaleSet.curSize = 1
+			scaleSet.lastSizeRefresh = time.Now()
+			scaleSet.sizeRefreshPeriod = time.Hour
+
+			// Create a poller that returns a non-preempted error
+			otherErrorPoller := newTestPollerWithError(errors.New("InternalServerError: something went wrong"))
+
+			// Act: PollUntilDone fails with a non-preempted error — should NOT trigger retry
+			scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds)
+
+			// Assert: BeginDeleteInstances was never called. gomock.Times(0) enforces this.
+			// Assert: caches were invalidated so TargetSize refreshes from VMSS capacity.
+			assert.False(t, scaleSet.lastInstanceRefresh.IsZero())
+			targetSize, err := scaleSet.TargetSize()
+			assert.NoError(t, err)
+			assert.Equal(t, 3, targetSize)
+		})
+	}
 }
 
 // TestScaleSetETagRetrySucceedsAfterPreconditionFailure verifies that a single 412

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -2382,6 +2382,70 @@ func TestScaleSetETagRetrySkippedWhenAlreadyAtTarget(t *testing.T) {
 	assert.Equal(t, 1, putCalls, "expected no second PUT when VMSS already at target")
 }
 
+// TestScaleSetETagRetryInvalidatesInstanceCache verifies that after an ETag precondition
+// refresh, the instance cache is invalidated so a stale deallocated/deallocating count is
+// not reused. In deallocate mode getScaleSetSize subtracts the deallocated instance count
+// (read from the instance cache) from the reported capacity; if a concurrent writer removed
+// instances out-of-band (the case ETag guards), the refreshed VMSS carries fresh capacity
+// but the instance cache would still hold the pre-change count, yielding an incorrect
+// (potentially negative) target size. The refresh must therefore mark the instance cache
+// stale so it is recomputed from fresh Azure state.
+func TestScaleSetETagRetryInvalidatesInstanceCache(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-dealloc-invalidate"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	// CA's cached view: stale ETag, capacity 3.
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name:       ptr.To(vmssName),
+		SKU:        &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+		Etag:       ptr.To(`W/"stale"`),
+	})
+
+	// The refresh GET returns a fresh VMSS already at/above the desired target so the retry
+	// takes the skip path (GET only, no second PUT). The cache invalidation runs regardless.
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name:       ptr.To(vmssName),
+			SKU:        &armcompute.SKU{Capacity: ptr.To[int64](5)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+			Etag:       ptr.To(`W/"fresh"`),
+		}, nil).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	scaleSet := newTestScaleSetDeallocateMode(manager, vmssName)
+	scaleSet.instancesRefreshPeriod = 10 * time.Minute
+	// Mark the instance cache as freshly refreshed so we can observe the invalidation.
+	scaleSet.lastInstanceRefresh = time.Now()
+	assert.True(t, scaleSet.lastInstanceRefresh.Add(scaleSet.instancesRefreshPeriod).After(time.Now()),
+		"precondition: instance cache should start valid")
+
+	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
+	defer cancel()
+
+	fresh, poller, err := scaleSet.retryCreateOrUpdateWithFreshETag(ctx, 4)
+	assert.NoError(t, err)
+	assert.Nil(t, poller, "already-at-target refresh should skip the retry PUT")
+	if assert.NotNil(t, fresh) && assert.NotNil(t, fresh.SKU) && assert.NotNil(t, fresh.SKU.Capacity) {
+		assert.Equal(t, int64(5), *fresh.SKU.Capacity)
+	}
+
+	// The instance cache must now be considered stale, forcing a fresh recompute of the
+	// deallocated/deallocating count on the next getScaleSetSize.
+	assert.False(t, scaleSet.lastInstanceRefresh.Add(scaleSet.instancesRefreshPeriod).After(time.Now()),
+		"ETag refresh should invalidate the instance cache")
+}
+
 // TestScaleSetETagReconcilesConcurrentWriter exercises the core scenario ETag mode is
 // meant to protect: another writer mutates the VMSS between CA's read and its write.
 // Using a mock that enforces optimistic concurrency like the real API, CA's first PUT

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -272,6 +272,40 @@ func TestScaleSetTargetSizeReturnsErrorForCachedNegativeSize(t *testing.T) {
 	assert.Equal(t, -1, size)
 }
 
+// TestScaleSetTargetSizeReturnsErrorForNegativeDeallocateAdjustedSize verifies the
+// deallocate-mode guard in getScaleSetSize: when the deallocated/deallocating count
+// (from the instance cache) exceeds the reported VMSS capacity — only possible when the
+// caches are inconsistent, e.g. instances removed out-of-band — the subtraction would go
+// negative, and we surface an error instead of publishing a negative target size.
+func TestScaleSetTargetSizeReturnsErrorForNegativeDeallocateAdjustedSize(t *testing.T) {
+	provider := newTestProvider(t)
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	scaleSet := newTestScaleSetDeallocateMode(provider.azureManager, testASG)
+	// Pin a valid reported capacity of 3 (avoid a live size refresh).
+	scaleSet.curSize = 3
+	scaleSet.lastSizeRefresh = time.Now()
+	scaleSet.sizeRefreshPeriod = time.Hour
+
+	// Seed the instance cache with more deallocated instances (5) than the reported
+	// capacity (3), simulating a stale cache after instances were removed out-of-band.
+	scaleSet.instanceCache = []cloudprovider.Instance{
+		{Id: "0", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+		{Id: "1", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+		{Id: "2", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+		{Id: "3", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+		{Id: "4", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+	}
+	scaleSet.lastInstanceRefresh = time.Now()
+	scaleSet.instancesRefreshPeriod = time.Hour
+
+	size, err := scaleSet.TargetSize()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "deallocated/deallocating instances is negative")
+	assert.Equal(t, -1, size)
+}
+
 func TestScaleSetIncreaseSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Release manifest

Release type: new revision
Target branch: `cluster-autoscaler-release-1.35.1-aks`
Upstream source: [cluster-autoscaler-release-1.35](https://github.com/kubernetes/autoscaler/tree/cluster-autoscaler-release-1.35) (post-`1.35.1` Azure fixes, upstream PR [#9881](https://github.com/kubernetes/autoscaler/pull/9881)) + one fork-local change
Candidate tag: `v1.35.1-aks-1-candidate` (applied after squash-merge)
Official tag: `v1.35.1-aks-1` (applied after image build)
Merge strategy: squash-merge

## Why this change

VMSS ETag optimistic concurrency (in `v1.35.1-aks`) protects the capacity-update path: when another writer changes the VMSS between CA's read and its write, CA's stale `If-Match` PUT is rejected with HTTP 412 instead of clobbering the change, and CA refreshes and retries. This closes the most damaging failure mode — a stale write shrinking the VMSS and terminating running nodes without drain/PDB.

However, in **deallocate mode** the ETag write-guard alone is not sufficient, because CA's target size is not the raw VMSS capacity — it is:

```
getScaleSetSize() = <VMSS capacity>  −  <deallocated/deallocating instance count>
```

Those two values come from **two different caches** (the size cache and the instance cache). When instances are removed out-of-band (for example, deallocated VMs deleted during a node-image upgrade), the two caches can disagree and the subtraction can yield an incorrect — potentially negative — target size. This revision hardens that path from two complementary directions:

1. **Refresh the instance cache after an ETag refresh** (fork-local). On a 412, `retryCreateOrUpdateWithFreshETag` fetches the current VMSS and updates the size cache, but previously left the instance cache untouched — so the deallocated count could remain stale and be subtracted from the fresh capacity. This change invalidates the instance cache in the refresh path so the count is recomputed from fresh state. Fixes the *root cause* of the stale count.
2. **Guard the size computation and delete paths** (upstream PR [#9881](https://github.com/kubernetes/autoscaler/pull/9881)). Prevents `getScaleSetSize`/`getCurSize` from ever returning or acting on a cached negative size, and invalidates the size cache on delete / delete-failure. A *safety net* independent of the ETag path.

### These two are independently necessary

Validated with the unit suite by toggling each fix's code while keeping its test:

| State | negative-size guard test | ETag-refresh instance-cache test |
|---|---|---|
| both changes | pass | pass |
| only the #9881 guard (instance-cache fix removed) | pass | **fail** |
| only the instance-cache fix (#9881 guard removed) | **fail** | pass |

Neither subsumes the other: the #9881 guard never touches the ETag retry path, and the instance-cache refresh never touches the size guard. Shipping both gives full coverage of the deallocate-mode + concurrent-modification race.

## Cherry-picks

| Working branch commit | Source commit | Message |
|---|---|---|
| [a9d83d87e](https://github.com/Azure/autoscaler/commit/a9d83d87eec0adaf2e8e6a8e0b88ec3a25040234) | [00268967a](https://github.com/kubernetes/autoscaler/commit/00268967ab0302b5ffbcd642deeb01841c23fa4c) (PR [#9881](https://github.com/kubernetes/autoscaler/pull/9881)) | fix(azure): prevent VMSS target size panic on cached negative size |
| [ad18d2393](https://github.com/Azure/autoscaler/commit/ad18d2393fdf781fb33773e43bcd7964fbada738) | [8b38219be](https://github.com/kubernetes/autoscaler/commit/8b38219be4386b3924c9d82b23843d3a4479b2df) (PR [#9881](https://github.com/kubernetes/autoscaler/pull/9881)) | fix(azure): avoid negative VMSS size cache on delete |
| [a86bfe0f1](https://github.com/Azure/autoscaler/commit/a86bfe0f1ac730590702dd860b91e9dfd5ba9bce) | [666049517](https://github.com/kubernetes/autoscaler/commit/666049517997d02532ffd1abb0d7b5578672f61e) (PR [#9881](https://github.com/kubernetes/autoscaler/pull/9881)) | fix: invalidate VMSS size cache on delete failure |

## Fork-local commit

- `fix(azure): invalidate instance cache after ETag refresh` — invalidates the instance cache after `retryCreateOrUpdateWithFreshETag` persists the refreshed VMSS, so the deallocated/deallocating count consumed by `getScaleSetSize` is recomputed from fresh Azure state. Adds `TestScaleSetETagRetryInvalidatesInstanceCache` (deallocate mode).

## Resolved conflicts

**`cluster-autoscaler/cloudprovider/azure/azure_scale_set.go`** (in `getScaleSetSize`)
- Upstream `00268967a` inserts a `size == -1` guard immediately after `getCurSize()`.
- The fork carries a deallocate-mode block in the same location (subtract deallocated/deallocating count from capacity).
- Resolution: keep **both** — the upstream `size == -1` guard first, then the fork's deallocate-mode subtraction.

## Validation

- `go build ./cloudprovider/azure/`: passing
- `gofmt -l` (changed files): clean
- `go test --test.short -race ./cloudprovider/azure/`: passing

## Relationship to the split PRs

The same two changes are also open as independent draft PRs (the #9881 cherry-picks; and the ETag-refresh instance-cache fix) for isolated review/E2E. This PR is the combined `v1.35.1-aks-1` revision that ships both together. `EnableVMSSEtag` remains at the upstream default; enabling ETag is handled via the `AZURE_ENABLE_VMSS_ETAG` environment variable.
