### PR TITLE
Disable AtomicIncreaseSize for deallocate scale-down policy (1.33)

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -433,13 +433,13 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 // for atomic-scale-up ProvisioningRequest support to provide a capacity guarantee
 // before workloads are admitted.
 //
-// Note: this currently only applies to delete scale down mode. This will be disabled for now 
+// Note: this currently only applies to delete scale down mode. This will be disabled for now
 // for deallocate mode.
 func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
 	if scaleSet.scaleDownPolicy == deallocate.Deallocate {
 		return cloudprovider.ErrNotImplemented
 	}
-	
+
 	size, err := scaleSet.canIncreaseSize(delta)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -432,7 +432,14 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 // "doesn't wait until the new instances appear" — the blocking behavior is required
 // for atomic-scale-up ProvisioningRequest support to provide a capacity guarantee
 // before workloads are admitted.
+//
+// Note: this currently only applies to delete scale down mode. This will be disabled for now 
+// for deallocate mode.
 func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
+	if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+		return cloudprovider.ErrNotImplemented
+	}
+	
 	size, err := scaleSet.canIncreaseSize(delta)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -658,6 +658,50 @@ func TestScaleSetAtomicIncreaseSizePollerFailure(t *testing.T) {
 	assert.Equal(t, 3, targetSize)
 }
 
+func TestScaleSetAtomicIncreaseSizeDeallocateNotImplemented(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", compute.Uniform)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	provider := newTestProvider(t)
+
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	// No CreateOrUpdateAsync call should be made for deallocate policy.
+	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]compute.VirtualMachine{}, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG, string(compute.InstanceViewTypesInstanceView)).Return(expectedVMSSVMs, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	ss := &ScaleSet{
+		azureRef:        azureRef{Name: testASG},
+		manager:         provider.azureManager,
+		minSize:         1,
+		maxSize:         5,
+		scaleDownPolicy: deallocate.Deallocate,
+	}
+	registered := provider.azureManager.RegisterNodeGroup(ss)
+	assert.True(t, registered)
+
+	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
+	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+
+	// Target size should remain unchanged (3).
+	targetSize, err := provider.NodeGroups()[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+}
+
 // TestIncreaseSizeOnVMProvisioningFailed has been tweeked only for Uniform Orchestration mode.
 // If ProvisioningState == failed and power state is not running, Status.State == InstanceCreating with errorInfo populated.
 func TestScaleSetIncreaseSizeOnVMProvisioningFailed(t *testing.T) {


### PR DESCRIPTION
## Summary

`AtomicIncreaseSize` is not implemented for the deallocate scale-down policy. This PR adds an early return of `cloudprovider.ErrNotImplemented` when `scaleDownPolicy == deallocate.Deallocate`, consistent with the existing comment in the function.

## Changes
- `azure_scale_set.go`: Return `ErrNotImplemented` immediately in `AtomicIncreaseSize` when scale-down policy is `Deallocate`
- `azure_scale_set_test.go`: Add `TestScaleSetAtomicIncreaseSizeDeallocateNotImplemented` to verify the early return and that no Azure API calls are made