### PR TITLE
[1.36] cluster-autoscaler (initial fork delta)

### DIFF
--- a/.agents/skills/run-azure-e2e-tests/SKILL.md
+++ b/.agents/skills/run-azure-e2e-tests/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: run-azure-e2e-tests
+description: 'Run Azure CAS end-to-end tests — per-suite execution with focus filtering, background execution, and local/CI workflows. Use when: running e2e tests, debugging test failures, adding new test suites.'
+---
+
+# E2E Tests for Azure CAS
+
+## Test Structure
+
+```
+cluster-autoscaler/cloudprovider/azure/test/
+├── suites/
+│   └── scaleup/             # Scale-up/down test
+│       └── suite_test.go
+├── pkg/
+│   └── environment/         # Shared Environment struct + helpers
+│       └── environment.go
+├── Makefile                  # Local + CI targets
+└── go.mod
+```
+
+## Local Developer Workflow
+
+From `cluster-autoscaler/cloudprovider/azure/test/`:
+
+### First-time setup
+
+```bash
+az login
+make setup-cluster      # Creates AKS + ACR + workload identity (~5 min)
+make deploy-local       # Builds + deploys CAS via skaffold (~1 min)
+```
+
+### Running tests
+
+```bash
+export AZURE_SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+export AZURE_RESOURCE_GROUP="MC_..."  # Node resource group (printed by setup-cluster)
+
+make e2etests                         # Run all suites
+make e2etests TEST_SUITE=scaleup      # Run single suite
+make e2etests FOCUS="scales up"       # Focus filter
+```
+
+### After code changes
+
+```bash
+make deploy-local       # Rebuild + redeploy CAS
+make e2etests TEST_SUITE=scaleup
+```
+
+### Utility commands
+
+- `make list-suites` — list available test suites
+- `make validate-env` — check required env vars
+- `make deploy-local-dev` — skaffold watch mode (auto-redeploy on changes)
+
+### Background execution (survives VPN drops)
+
+```bash
+nohup make e2etests TEST_SUITE=scaleup > e2e.log 2>&1 &
+tail -f e2e.log
+```
+
+## CI (Prow)
+
+`make test-e2e` builds the CAS image and deploys via Helm (inside BeforeSuite), using cluster info from CAPZ. The Helm deploy is triggered by `-cas-image-repository` and `-cas-image-tag` flags — when absent (local path), Helm is skipped.
+
+## Monitoring
+
+- **Logs**: `tail -f e2e.log`
+- **Cluster**: `kubectl get nodes,pods -w`
+- **Events**: `kubectl get events -A --field-selector source=cluster-autoscaler --watch`
+- **VMSS**: `az vmss list -g $AZURE_RESOURCE_GROUP -o table`
+- **CAS logs**: `kubectl logs -n kube-system deploy/cluster-autoscaler -f`
+
+## Adding a New Test Suite
+
+1. Create `test/suites/<name>/suite_test.go`
+2. Import `pkg/environment` for shared helpers
+3. Register `-resource-group` flag in `init()`
+4. Create `Environment` in `BeforeSuite`, call `EnsureHelmRelease(...)` for CI compatibility
+5. Run: `make e2etests TEST_SUITE=<name>`

--- a/.azuredevops/pull_request_template.md
+++ b/.azuredevops/pull_request_template.md
@@ -1,0 +1,40 @@
+**What type of PR is this?** (bug, cleanup, documentation, feature)
+
+**What this PR does / why we need it?**:
+
+**Does this PR introduce a user-facing change?**
+
+**WorkItem**
+<!--- NOTE: REPLACE THIS LINE WITH THE WORKITEM SUFFIXED WITH "https://dev.azure.com/msazure/CloudNativeCompute".
+Currently, this CAS repo is under  "https://dev.azure.com/AzureContainerUpstream", workItems are under "https://dev.azure.com/msazure/CloudNativeCompute" and ADO doesn't support cross-linking.---->
+
+**Testing**
+- [ ] Unit tests
+- [ ] E2E tests (we can custom branches on standalone env only)
+- [ ] Other tests (eg. manual testing).
+
+<details>
+<summary>Cherry-pick details</summary>
+
+**Is this a cherry-picked PR?**
+- [ ] Yes. Include original PR.
+```
+```
+- [ ] No. On which internal versions / branches is this PR getting cherry-picked ?
+```
+```
+
+**Is this PR getting merged on [upstream](https://github.com/kubernetes/autoscaler) ?**
+- [ ] Yes. Which branches / versions including master?
+```
+```
+- [ ] No. Why?
+```
+```
+</details>
+
+<br>
+
+**Special notes for your reviewer**:
+
+**Additional Documentation**:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,32 +1,52 @@
 {
-  "name": "Kubernetes Autoscaler Development",
-  "image": "mcr.microsoft.com/devcontainers/go:1.26",
+	"name": "Azure CAS Dev",
+	"image": "mcr.microsoft.com/devcontainers/go:1.26",
+	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 
-  "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "dockerDashComposeVersion": "v2",
-      "moby": false
-    },
-    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
-      "minikube": "latest"
-    },
-    "ghcr.io/devcontainers/features/github-cli:1": {}
-  },
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/azure-cli:1": {},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"helm": "latest",
+			"minikube": "none"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/rio/features/skaffold:2": {}
+	},
 
-  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends libseccomp-dev",
+	"onCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends libseccomp-dev",
 
-  "postCreateCommand": "cd cluster-autoscaler && go mod download && cd .. && cd vertical-pod-autoscaler && go mod download && cd .. && hack/install-verify-tools.sh && go install sigs.k8s.io/kind@latest",
+	"postCreateCommand": {
+		"download cluster-autoscaler modules": "cd cluster-autoscaler && go mod download",
+		"download vertical-pod-autoscaler modules": "cd vertical-pod-autoscaler && go mod download",
+		"install verify tools": "hack/install-verify-tools.sh",
+		"install kind": "go install sigs.k8s.io/kind@latest",
+		"install ko": "go install github.com/google/ko@latest",
+		"install yq": "go install github.com/mikefarah/yq/v4@latest",
+		"disable skaffold metrics": "skaffold config set --global collect-metrics false"
+	},
 
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "golang.go"
-      ],
-      "settings": {
-        "go.testFlags": ["-race", "-count=1"],
-        "go.lintTool": "golangci-lint",
-        "go.lintOnSave": "workspace"
-      }
-    }
-  }
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go",
+				"ms-kubernetes-tools.vscode-kubernetes-tools",
+				"ms-kubernetes-tools.vscode-aks-tools",
+				"ms-azuretools.vscode-bicep",
+				"GitHub.vscode-pull-request-github",
+				"GitHub.copilot-chat"
+			],
+			"settings": {
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go",
+				"go.testFlags": ["-race", "-count=1"],
+				"go.lintTool": "golangci-lint",
+				"go.lintOnSave": "workspace",
+				"chat.useAgentSkills": true
+			}
+		}
+	},
+
+	"remoteUser": "vscode"
 }

--- a/.pipelines/cluster-autoscaler.yaml
+++ b/.pipelines/cluster-autoscaler.yaml
@@ -1,0 +1,56 @@
+pr:
+  - master
+  - cluster-autoscaler-release-*
+
+variables:
+- name: GOPATH
+  value: $(Agent.BuildDirectory)/go
+- name: GOBIN
+  value: $(GOPATH)/bin
+- name: GO111MODULE
+  value: auto
+- name: autoscaler.clone.dir
+  value: go/src/k8s.io/autoscaler
+# There are many references to alternative container registries in this repository, including
+# in sample deployment artifacts for other cloud providers, and in VPA; none of these are relevant for this build.
+# Disable container registry analysis to eliminate noise. For more information please visit: https://aka.ms/sscatask
+- name: DisableDockerDetector
+  value: true
+- name: DisableKubernetesDeploymentDetector
+  value: true
+
+jobs:
+  - job: cluster_autoscaler_test
+    pool: staging-pool-amd64-mariner-2
+    displayName: Autoscaler Unit Tests
+    workspace:
+      clean: all
+    steps:
+    - checkout: self
+      path: $(autoscaler.clone.dir)
+      fetchDepth: "1"
+    - script: |
+        echo '##vso[task.prependpath]$(GOPATH)/bin'
+        hack/install-verify-tools.sh
+        go install github.com/t-yuki/gocover-cobertura@master
+      displayName: "Prepare"
+    - task: UseDotNet@2
+      inputs:
+        version: 7.0.x
+      displayName: 'Prepare .NET Core SDK'
+    - script: |
+        hack/verify-all.sh -v
+      displayName: "Verify"
+    - script: |
+        cd cluster-autoscaler
+        go mod tidy
+        go test -v -coverprofile=coverage.txt -covermode=atomic -race $(go list ./... | grep -v vertical-pod-autoscaler/e2e | grep -v /cloudprovider/ && go list ./cloudprovider/azure/...)
+      displayName: "Test"
+    - script: |
+        gocover-cobertura < '$(System.DefaultWorkingDirectory)/cluster-autoscaler/coverage.txt' > '$(System.DefaultWorkingDirectory)/cluster-autoscaler/coverage.xml'
+      displayName: 'Convert'
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        codeCoverageTool: 'Cobertura'
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/cluster-autoscaler/coverage.xml'
+      displayName: 'Publish Coverage'

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.0
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.0
 
 ENV GOPATH=/gopath/
 ENV PATH=$GOPATH/bin:$PATH

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -148,7 +148,7 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
 	cfg.StrictCacheUpdates = false
 	cfg.EnableLabelPredictionsOnTemplate = true
-	cfg.EnableVMSSEtag = false
+	cfg.EnableVMSSEtag = false // TODO(follow-up): add fork-specific etag support; upstream default kept for v1.35.1-aks
 
 	// Config file overrides defaults
 	if configReader != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -210,7 +210,7 @@ func (m *AzureManager) buildNodeGroupFromSpec(spec string) (cloudprovider.NodeGr
 	if strings.EqualFold(m.config.VMType, providerazureconsts.VMTypeVMSS) {
 		scaleToZeroSupported = scaleToZeroSupportedVMSS
 	}
-	s, err := dynamic.SpecFromString(spec, scaleToZeroSupported)
+	s, err := dynamic.SpecFromStringWithLabelsAndTaints(spec, scaleToZeroSupported)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse node group spec: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/utils/ptr"
 	azclient "sigs.k8s.io/cloud-provider-azure/pkg/azclient"
@@ -771,7 +772,7 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 	min, max, name := 1, 15, "test-asg"
 	ngdo := cloudprovider.NodeGroupDiscoveryOptions{
 		NodeGroupSpecs: []string{
-			fmt.Sprintf("%d:%d:%s", min, max, name),
+			fmt.Sprintf("%d:%d:%s:%s", min, max, deallocate.Delete, name),
 		},
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_mock_vmss_delete_client_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_mock_vmss_delete_client_test.go
@@ -87,3 +87,33 @@ func (mr *MockVMSSDeleteClientMockRecorder) BeginDeleteInstances(ctx, resourceGr
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginDeleteInstances", reflect.TypeOf((*MockVMSSDeleteClient)(nil).BeginDeleteInstances), ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs, options)
 }
+
+// BeginStart mocks base method.
+func (m *MockVMSSDeleteClient) BeginStart(ctx context.Context, resourceGroupName, vmScaleSetName string, options *armcompute.VirtualMachineScaleSetsClientBeginStartOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientStartResponse], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BeginStart", ctx, resourceGroupName, vmScaleSetName, options)
+	ret0, _ := ret[0].(*runtime.Poller[armcompute.VirtualMachineScaleSetsClientStartResponse])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BeginStart indicates an expected call of BeginStart.
+func (mr *MockVMSSDeleteClientMockRecorder) BeginStart(ctx, resourceGroupName, vmScaleSetName, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginStart", reflect.TypeOf((*MockVMSSDeleteClient)(nil).BeginStart), ctx, resourceGroupName, vmScaleSetName, options)
+}
+
+// BeginDeallocate mocks base method.
+func (m *MockVMSSDeleteClient) BeginDeallocate(ctx context.Context, resourceGroupName, vmScaleSetName string, options *armcompute.VirtualMachineScaleSetsClientBeginDeallocateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeallocateResponse], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BeginDeallocate", ctx, resourceGroupName, vmScaleSetName, options)
+	ret0, _ := ret[0].(*runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeallocateResponse])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BeginDeallocate indicates an expected call of BeginDeallocate.
+func (mr *MockVMSSDeleteClientMockRecorder) BeginDeallocate(ctx, resourceGroupName, vmScaleSetName, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginDeallocate", reflect.TypeOf((*MockVMSSDeleteClient)(nil).BeginDeallocate), ctx, resourceGroupName, vmScaleSetName, options)
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -31,6 +31,7 @@ import (
 	azerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -64,9 +65,11 @@ type ScaleSet struct {
 	azureRef
 	manager *AzureManager
 
-	minSize int
-	maxSize int
-
+	minSize                   int
+	maxSize                   int
+	labels                    map[string]string
+	taints                    string
+	scaleDownPolicy           deallocate.ScaleDownPolicy
 	enableForceDelete         bool
 	enableDynamicInstanceList bool
 	enableDetailedCSEMessage  bool
@@ -107,8 +110,11 @@ func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager, curSize int64, d
 			Name: spec.Name,
 		},
 
-		minSize: spec.MinSize,
-		maxSize: spec.MaxSize,
+		minSize:         spec.MinSize,
+		maxSize:         spec.MaxSize,
+		labels:          spec.Labels,
+		taints:          spec.Taints,
+		scaleDownPolicy: spec.ScaleDownPolicy,
 
 		manager:           az,
 		curSize:           curSize,
@@ -185,6 +191,11 @@ func (scaleSet *ScaleSet) GetOptions(defaults config.NodeGroupAutoscalingOptions
 		return nil, nil
 	}
 	return scaleSet.manager.GetScaleSetOptions(*template.Name, defaults), nil
+}
+
+// ScaleDownPolicy returns the policy for the node group on scale downs. Whether Delete or Deallocate.
+func (scaleSet *ScaleSet) ScaleDownPolicy() deallocate.ScaleDownPolicy {
+	return scaleSet.scaleDownPolicy
 }
 
 // MaxSize returns maximum size of the node group.
@@ -285,6 +296,28 @@ func (scaleSet *ScaleSet) getScaleSetSize() (int64, error) {
 		klog.V(3).Infof("getScaleSetSize: size is -1 (actual err:%v)", err)
 		return size, err
 	}
+	// If the policy for this ScaleSet is Deallocate, the TargetSize is the capacity reported by VMSS minus the nodes in deallocated and deallocating states
+	if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+		totalDeallocationInstances, err := scaleSet.countDeallocatedDeallocatingInstances()
+		if err != nil {
+			klog.Errorf("getScaleSetSize: error countDeallocatedDeallocatingInstances for scaleSet %s,err: %v",
+				scaleSet.Name, err)
+			return -1, err
+		}
+		size -= int64(totalDeallocationInstances)
+		if size < 0 {
+			// A negative deallocate-adjusted size means the deallocated/deallocating count
+			// exceeds the reported capacity, which is only possible when the caches are
+			// inconsistent (e.g. instances removed out-of-band). Surface it as an error
+			// rather than publishing a negative target, mirroring the size == -1 guard above.
+			err := fmt.Errorf("failed to get scale set size for %s: capacity minus %d deallocated/deallocating instances is negative (%d); instance cache likely stale",
+				scaleSet.Name, totalDeallocationInstances, size)
+			klog.V(3).Infof("getScaleSetSize: negative deallocate-adjusted size (actual err:%v)", err)
+			return -1, err
+		}
+		klog.V(3).Infof("Found: %d instances in deallocated state, returning target size: %d for scaleSet %s",
+			totalDeallocationInstances, size, scaleSet.Name)
+	}
 	return size, nil
 }
 
@@ -297,6 +330,32 @@ func (scaleSet *ScaleSet) setScaleSetSize(size int64, delta int) error {
 	}
 
 	requiredInstances := delta
+	// If the policy is deallocate, then attempt to satisfy the request by starting existing instances
+	if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+		deallocatedInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceDeallocated)
+		if err != nil {
+			klog.Errorf("setScaleSetSize: error getInstancesByState for dealloacted for scaleSet %s, "+
+				"err : %v", scaleSet.Name, err)
+		} else {
+			klog.V(3).Infof("Attempting to start: %d instances from deallocated state", requiredInstances)
+
+			// Go through current instances and attempt to reallocate them
+			for _, instance := range deallocatedInstances {
+				// we're done
+				if requiredInstances <= 0 {
+					break
+				}
+				ref := &azureRef{Name: instance.Id}
+				err := scaleSet.startInstance(ref)
+				if err != nil {
+					klog.Errorf("Failed to start instance %s in scale set %q: %v", instance.Id, scaleSet.Name, err)
+					continue
+				}
+				klog.V(3).Infof("Successfully started instance %s in scale set %q", instance.Id, scaleSet.Name)
+				requiredInstances--
+			}
+		}
+	}
 
 	// If after reallocating instances we still need more instances or we're just in Delete mode
 	// send a scale request
@@ -365,7 +424,14 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 // "doesn't wait until the new instances appear" — the blocking behavior is required
 // for atomic-scale-up ProvisioningRequest support to provide a capacity guarantee
 // before workloads are admitted.
+//
+// Note: this currently only applies to delete scale down mode. This will be disabled for now
+// for deallocate mode.
 func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
+	if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+		return cloudprovider.ErrNotImplemented
+	}
+
 	size, err := scaleSet.canIncreaseSize(delta)
 	if err != nil {
 		return err
@@ -606,6 +672,14 @@ func (scaleSet *ScaleSet) retryCreateOrUpdateWithFreshETag(ctx context.Context, 
 	// Persist the freshly-fetched VMSS (ETag and capacity) for subsequent operations.
 	scaleSet.manager.azureCache.setScaleSet(scaleSet.Name, fresh)
 
+	// The refreshed VMSS reflects the concurrent writer's change (for example, instances
+	// removed by an out-of-band delete while in deallocate mode). Invalidate the instance
+	// cache so the deallocated/deallocating count consumed by getScaleSetSize is recomputed
+	// from fresh Azure state; otherwise a stale count could be subtracted from the fresh
+	// capacity and yield an incorrect (potentially negative) target size. Callers of this
+	// method hold sizeMutex; invalidateInstanceCache guards the instance cache separately.
+	scaleSet.invalidateInstanceCache()
+
 	// If another writer already grew the VMSS to at least our target, the desired floor
 	// is already met; don't issue a PUT that would shrink it back down. Return the fresh
 	// object (nil poller) so the caller publishes its actual capacity, not a stale target.
@@ -728,6 +802,188 @@ func (scaleSet *ScaleSet) waitForCreateOrUpdateInstances(poller *runtime.Poller[
 	}
 
 	klog.V(3).Infof("PollUntilDone for CreateOrUpdate(%s) success", scaleSet.Name)
+}
+
+// startInstance starts a single deallocated instance.
+func (scaleSet *ScaleSet) startInstance(instance *azureRef) error {
+	klog.V(3).Infof("Starting vmss instance %s", instance.Name)
+
+	ng, err := scaleSet.manager.GetNodeGroupForInstance(instance)
+	if err != nil {
+		return err
+	}
+
+	if err := scaleSet.verifyNodeGroup(instance, ng.Id()); err != nil {
+		return err
+	}
+
+	if cpi, found, err := scaleSet.getInstanceByProviderID(instance.Name); found && err == nil {
+		if cpi.Status != nil && cpi.Status.State == cloudprovider.InstanceRunning {
+			klog.V(3).Infof("Skipping starting instance %s as its current state is running", instance.Name)
+			return nil
+		}
+	}
+
+	instanceID, err := getLastSegment(instance.Name)
+	if err != nil {
+		klog.Errorf("getLastSegment failed with error: %v", err)
+		return err
+	}
+
+	ctx, cancel := getContextWithTimeout(vmssContextTimeout)
+	defer cancel()
+	resourceGroup := scaleSet.manager.config.ResourceGroup
+
+	scaleSet.instanceMutex.Lock()
+	klog.V(3).Infof("Calling BeginStart(%s) for %s", instanceID, scaleSet.Name)
+	opts := &armcompute.VirtualMachineScaleSetsClientBeginStartOptions{
+		VMInstanceIDs: &armcompute.VirtualMachineScaleSetVMInstanceIDs{
+			InstanceIDs: []*string{&instanceID},
+		},
+	}
+	poller, err := scaleSet.manager.azClient.vmssClientForDelete.BeginStart(ctx, resourceGroup, ng.Id(), opts)
+	scaleSet.instanceMutex.Unlock()
+	if err != nil {
+		klog.Errorf("BeginStart for instance %s for %s failed: %+v", instanceID, scaleSet.Name, err)
+		return err
+	}
+
+	// Proactively set the status of the instance to running in cache
+	scaleSet.setInstanceStatusByProviderID(instance.Name, cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning})
+
+	if poller != nil {
+		go scaleSet.waitForStartInstance(poller, instanceID)
+	}
+	return nil
+}
+
+func (scaleSet *ScaleSet) waitForStartInstance(poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientStartResponse], instanceID string) {
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+	klog.V(3).Infof("Calling PollUntilDone for Start(%s) for %s", instanceID, scaleSet.Name)
+	_, err := poller.PollUntilDone(ctx, nil)
+	if err == nil {
+		klog.V(3).Infof("PollUntilDone for Start(%s) for %s success", instanceID, scaleSet.Name)
+		// No need to invalidateInstanceCache because the state was proactively set to Running.
+		return
+	}
+
+	scaleSet.invalidateInstanceCache()
+	klog.Errorf("PollUntilDone for Start(%s) for %s failed with error: %v",
+		instanceID, scaleSet.Name, err)
+}
+
+// deallocateInstances deallocates the given instances. All instances must be controlled by the same nodegroup.
+func (scaleSet *ScaleSet) deallocateInstances(instances []*azureRef) error {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	klog.V(3).Infof("Deallocating vmss instances %v", instances)
+
+	commonNg, err := scaleSet.manager.GetNodeGroupForInstance(instances[0])
+	if err != nil {
+		return err
+	}
+
+	instancesToDeallocate := []*azureRef{}
+	for _, instance := range instances {
+		err = scaleSet.verifyNodeGroup(instance, commonNg.Id())
+		if err != nil {
+			return err
+		}
+
+		// Instances in the "InstanceDeallocated" state are the only ones currently being ignored. However, if the
+		// deallocation process fails for instances in the "InstanceDeallocating" state, we are currently invalidating
+		// the cache by calling "waitForDeallocateInstances()" without implementing proper error handling for these cases.
+		// Consequently, we do not intend to skip these instances. This approach is simply a conservative measure to
+		// ensure that all instances are accounted.
+		if cpi, found, err := scaleSet.getInstanceByProviderID(instance.Name); found && err == nil && cpi.Status != nil &&
+			cpi.Status.State == cloudprovider.InstanceDeallocated {
+			klog.V(3).Infof("Skipping deallocating instance %s as its current state is deallocated", instance.Name)
+			continue
+		}
+		instancesToDeallocate = append(instancesToDeallocate, instance)
+	}
+
+	// nothing to delete
+	if len(instancesToDeallocate) == 0 {
+		klog.V(3).Infof("No new instances eligible for deallocation, skipping")
+		return nil
+	}
+
+	instanceIDs := []string{}
+	for _, instance := range instancesToDeallocate {
+		instanceID, err := getLastSegment(instance.Name)
+		if err != nil {
+			klog.Errorf("getLastSegment failed with error: %v", err)
+			return err
+		}
+		instanceIDs = append(instanceIDs, instanceID)
+	}
+
+	// Convert []string to []*string
+	instanceIDPtrs := make([]*string, len(instanceIDs))
+	for i := range instanceIDs {
+		instanceIDPtrs[i] = &instanceIDs[i]
+	}
+
+	ctx, cancel := getContextWithTimeout(vmssContextTimeout)
+	defer cancel()
+	resourceGroup := scaleSet.manager.config.ResourceGroup
+
+	scaleSet.instanceMutex.Lock()
+	klog.V(3).Infof("Calling BeginDeallocate(%v) for %s", instanceIDs, scaleSet.Name)
+	poller, err := scaleSet.manager.azClient.vmssClientForDelete.BeginDeallocate(ctx, resourceGroup, commonNg.Id(), &armcompute.VirtualMachineScaleSetsClientBeginDeallocateOptions{
+		VMInstanceIDs: &armcompute.VirtualMachineScaleSetVMInstanceIDs{
+			InstanceIDs: instanceIDPtrs,
+		},
+	})
+	scaleSet.instanceMutex.Unlock()
+	if err != nil {
+		klog.Errorf("BeginDeallocate for instances %v for %s failed: %+v", instanceIDs, scaleSet.Name, err)
+		return err
+	}
+
+	// Proactively set the status of the instances to be running in cache as deallocating. Status will change to deallocated on success
+	for _, instance := range instancesToDeallocate {
+		scaleSet.setInstanceStatusByProviderID(instance.Name, cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocating})
+	}
+
+	if poller != nil {
+		go scaleSet.waitForDeallocateInstances(poller, instancesToDeallocate, instanceIDPtrs)
+	}
+
+	return nil
+}
+
+func (scaleSet *ScaleSet) waitForDeallocateInstances(poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeallocateResponse], instancesToDeallocate []*azureRef,
+	instanceIDs []*string) {
+	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
+	defer cancel()
+	klog.V(3).Infof("Calling PollUntilDone for Deallocate(%v) for %s", instanceIDs, scaleSet.Name)
+	_, err := poller.PollUntilDone(ctx, nil)
+	if err == nil {
+		klog.V(3).Infof("PollUntilDone for Deallocate(%v) for %s success",
+			instanceIDs, scaleSet.Name)
+		// Set the status of the instances to deallocated only if PollUntilDone succeeds.
+		// Use setInstanceStatusIfNotSuperseded to avoid overwriting state set by a newer
+		// concurrent operation (e.g., startInstance setting InstanceRunning, or DeleteInstances
+		// setting InstanceDeleting) that occurred while this goroutine was waiting.
+		// In the happy path, instance state here is InstanceDeallocating (set proactively by
+		// deallocateInstances before launching this goroutine). InstanceRunning and InstanceDeleting
+		// are only possible if a concurrent startInstance or DeleteInstances raced with this
+		// deallocate operation — those newer operations take precedence.
+		for _, instance := range instancesToDeallocate {
+			scaleSet.setInstanceStatusIfNotSuperseded(instance.Name,
+				cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+				[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		}
+		return
+	}
+
+	scaleSet.invalidateInstanceCache()
+	klog.Errorf("PollUntilDone for Deallocate(%v) for %s failed with error: %v", instanceIDs, scaleSet.Name, err)
 }
 
 // DeleteInstances deletes the given instances. All instances must be controlled by the same nodegroup.
@@ -916,6 +1172,9 @@ func (scaleSet *ScaleSet) ForceDeleteNodes(nodes []*apiv1.Node) error {
 		refs = append(refs, ref)
 	}
 
+	if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+		return scaleSet.deallocateInstances(refs)
+	}
 	return scaleSet.DeleteInstances(refs, hasUnregisteredNodes)
 }
 
@@ -936,9 +1195,7 @@ func (scaleSet *ScaleSet) TemplateNodeInfo() (*framework.NodeInfo, error) {
 		return nil, err
 	}
 
-	inputLabels := map[string]string{}
-	inputTaints := ""
-	template, err := buildNodeTemplateFromVMSS(vmss, inputLabels, inputTaints)
+	template, err := buildNodeTemplateFromVMSS(vmss, scaleSet.labels, scaleSet.taints)
 	if err != nil {
 		return nil, err
 	}
@@ -1208,6 +1465,22 @@ func (scaleSet *ScaleSet) getSKU() string {
 		return ""
 	}
 	return ptr.Deref(vmssInfo.SKU.Name, "")
+}
+
+func (scaleSet *ScaleSet) countDeallocatedDeallocatingInstances() (int, error) {
+	deallocatedInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceDeallocated)
+	if err != nil {
+		klog.Errorf("getScaleSetSize: error getInstancesByState for deallocated state for scaleSet %s,err: %v",
+			scaleSet.Name, err)
+		return -1, err
+	}
+	deallocatingInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceDeallocating)
+	if err != nil {
+		klog.Errorf("getScaleSetSize: error getInstancesByState for deallocating state for scaleSet %s,err: %v",
+			scaleSet.Name, err)
+		return -1, err
+	}
+	return len(deallocatedInstances) + len(deallocatingInstances), nil
 }
 
 func (scaleSet *ScaleSet) verifyNodeGroup(instance *azureRef, commonNgID string) error {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_deallocate_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_deallocate_test.go
@@ -1,0 +1,438 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachineclient/mock_virtualmachineclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetclient/mock_virtualmachinescalesetclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/mock_virtualmachinescalesetvmclient"
+)
+
+// fakeSuccessHandler implements runtime.PollingHandler and always reports done with no error.
+type fakeSuccessHandler[T any] struct{}
+
+func (f *fakeSuccessHandler[T]) Done() bool                                       { return true }
+func (f *fakeSuccessHandler[T]) Poll(ctx context.Context) (*http.Response, error) { return nil, nil }
+func (f *fakeSuccessHandler[T]) Result(ctx context.Context, out *T) error         { return nil }
+
+// fakeErrorHandler implements runtime.PollingHandler and always reports done with an error.
+type fakeErrorHandler[T any] struct {
+	err error
+}
+
+func (f *fakeErrorHandler[T]) Done() bool                                       { return true }
+func (f *fakeErrorHandler[T]) Poll(ctx context.Context) (*http.Response, error) { return nil, nil }
+func (f *fakeErrorHandler[T]) Result(ctx context.Context, out *T) error         { return f.err }
+
+func newFakeStartPoller(handler runtime.PollingHandler[armcompute.VirtualMachineScaleSetsClientStartResponse]) *runtime.Poller[armcompute.VirtualMachineScaleSetsClientStartResponse] {
+	resp := &http.Response{Header: map[string][]string{"Fake-Poller-Status": {"Done"}}}
+	p, _ := runtime.NewPoller(resp, runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetsClientStartResponse]{Handler: handler})
+	return p
+}
+
+func newFakeDeallocatePoller(handler runtime.PollingHandler[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]) *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeallocateResponse] {
+	resp := &http.Response{Header: map[string][]string{"Fake-Poller-Status": {"Done"}}}
+	p, _ := runtime.NewPoller(resp, runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]{Handler: handler})
+	return p
+}
+
+func TestDeallocateNodes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	cases := []struct {
+		name              string
+		orchestrationMode armcompute.OrchestrationMode
+		enableForceDelete bool
+		scaleDownPolicy   deallocate.ScaleDownPolicy
+	}{
+		{
+			name:              "uniform, force delete enabled, deallocate mode",
+			orchestrationMode: armcompute.OrchestrationModeUniform,
+			enableForceDelete: true,
+			scaleDownPolicy:   deallocate.Deallocate,
+		},
+		{
+			name:              "uniform, force delete disabled, deallocate mode",
+			orchestrationMode: armcompute.OrchestrationModeUniform,
+			enableForceDelete: false,
+			scaleDownPolicy:   deallocate.Deallocate,
+		},
+		/* Flex + Deallocate is not supported yet
+		{
+			name:              "flexible, force delete enabled, deallocate mode",
+			orchestrationMode: armcompute.OrchestrationModeFlexible,
+			enableForceDelete: true,
+			scaleDownPolicy:   deallocate.Deallocate,
+		},
+		{
+			name:              "flexible, force delete disabled, deallocate mode",
+			orchestrationMode: armcompute.OrchestrationModeFlexible,
+			enableForceDelete: false,
+			scaleDownPolicy:   deallocate.Deallocate,
+		},
+		*/
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orchMode := tc.orchestrationMode
+			enableForceDelete := tc.enableForceDelete
+			scaleDownPolicy := tc.scaleDownPolicy
+
+			expectedVMSSVMs := newTestVMSSVMList(3)
+			expectedVMs := newTestVMList(3)
+
+			manager := newTestAzureManager(t)
+			manager.config.EnableForceDelete = enableForceDelete
+			expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", orchMode)
+
+			mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
+
+			mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+			if scaleDownPolicy == deallocate.Delete {
+				mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+			} else {
+				mockDeleteClient.EXPECT().BeginDeallocate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+			}
+
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+			manager.azClient.vmssClientForDelete = mockDeleteClient
+
+			mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+			mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+
+			if orchMode == armcompute.OrchestrationModeUniform {
+				mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+				manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+			} else {
+				manager.config.EnableVmssFlexNodes = true
+				mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedVMs, nil).AnyTimes()
+				manager.azClient.virtualMachinesClient = mockVMClient
+			}
+
+			err := manager.forceRefresh()
+			assert.NoError(t, err)
+
+			resourceLimiter := cloudprovider.NewResourceLimiter(
+				map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+				map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+			provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+
+			assert.NoError(t, err)
+
+			registered := manager.RegisterNodeGroup(
+				newTestScaleSet(manager, testASG))
+			manager.explicitlyConfigured[testASG] = true
+
+			assert.True(t, registered)
+			err = manager.forceRefresh()
+			assert.NoError(t, err)
+
+			scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+			assert.True(t, ok)
+
+			targetSize, err := scaleSet.TargetSize()
+			assert.NoError(t, err)
+			assert.Equal(t, 3, targetSize)
+
+			scaleSet.scaleDownPolicy = scaleDownPolicy
+
+			// Perform the delete operation
+			nodesToDelete := []*apiv1.Node{
+				newApiNode(orchMode, 0),
+				newApiNode(orchMode, 2),
+			}
+			err = scaleSet.DeleteNodes(nodesToDelete)
+			assert.NoError(t, err)
+
+			if scaleDownPolicy == deallocate.Delete {
+				// create scale set with vmss capacity 1
+				expectedScaleSets = newTestVMSSList(1, vmssName, "eastus", orchMode)
+			} else {
+				// create scale set with vmss capacity 3
+				expectedScaleSets = newTestVMSSList(3, vmssName, "eastus", orchMode)
+			}
+
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+
+			if orchMode == armcompute.OrchestrationModeUniform {
+				if scaleDownPolicy == deallocate.Delete {
+					expectedVMSSVMs[0].Properties.ProvisioningState = ptr.To(VMProvisioningStateDeleting)
+					expectedVMSSVMs[2].Properties.ProvisioningState = ptr.To(VMProvisioningStateDeleting)
+				} else {
+					// DeleteNodes above waits for results in a goroutine, and deallocate implementation (waitForDeallocateInstancesResult)
+					// currently accesses cache and adjusts provisioning state directly, so need to lock the instanceMutex to avoid data races
+					// (Locks around scaleSet.lastInstanceRefresh below are added for the same reason)
+					scaleSet.instanceMutex.Lock()
+					expectedVMSSVMs[0].Properties.ProvisioningState = ptr.To(provisioningStateSucceeded)
+					expectedVMSSVMs[2].Properties.ProvisioningState = ptr.To(provisioningStateSucceeded)
+					expectedVMSSVMs[0].Properties.InstanceView = &armcompute.VirtualMachineScaleSetVMInstanceView{Statuses: []*armcompute.InstanceViewStatus{{Code: ptr.To(vmPowerStateDeallocating)}}}
+					expectedVMSSVMs[2].Properties.InstanceView = &armcompute.VirtualMachineScaleSetVMInstanceView{Statuses: []*armcompute.InstanceViewStatus{{Code: ptr.To(vmPowerStateDeallocating)}}}
+					scaleSet.instanceMutex.Unlock()
+
+				}
+				mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+			} else {
+				if scaleDownPolicy == deallocate.Delete {
+					expectedVMs[0].Properties.ProvisioningState = ptr.To(VMProvisioningStateDeleting)
+					expectedVMs[2].Properties.ProvisioningState = ptr.To(VMProvisioningStateDeleting)
+				} else {
+					// Flex + Deallocate is not supported yet; is not tested here, fail just in case
+					assert.Fail(t, "flexible orchestration mode does not support deallocate")
+				}
+				mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedVMs, nil).AnyTimes()
+			}
+
+			err = manager.forceRefresh()
+			assert.NoError(t, err)
+
+			// Ensure the the cached size has been proactively decremented by 2
+			targetSize, err = scaleSet.TargetSize()
+			assert.NoError(t, err)
+			assert.Equal(t, 1, targetSize)
+
+			// Ensure that the status for the instances is Deleting or Deallocated
+			// lastInstanceRefresh is set to time.Now() to avoid resetting instanceCache.
+			scaleSet.instanceMutex.Lock()
+			scaleSet.lastInstanceRefresh = time.Now()
+			scaleSet.instanceMutex.Unlock()
+
+			instance0, found, err := scaleSet.getInstanceByProviderID(nodesToDelete[0].Spec.ProviderID)
+			assert.True(t, found, true)
+			assert.NoError(t, err)
+			if scaleDownPolicy == deallocate.Delete {
+				assert.Equal(t, cloudprovider.InstanceDeleting, instance0.Status.State)
+			} else {
+				assert.Equal(t, cloudprovider.InstanceDeallocating, instance0.Status.State)
+			}
+
+			// lastInstanceRefresh is set to time.Now() to avoid resetting instanceCache.
+			scaleSet.instanceMutex.Lock()
+			scaleSet.lastInstanceRefresh = time.Now()
+			scaleSet.instanceMutex.Unlock()
+
+			instance2, found, err := scaleSet.getInstanceByProviderID(nodesToDelete[1].Spec.ProviderID)
+			assert.True(t, found, true)
+			assert.NoError(t, err)
+			if scaleDownPolicy == deallocate.Delete {
+				assert.Equal(t, cloudprovider.InstanceDeleting, instance2.Status.State)
+			} else {
+				assert.Equal(t, cloudprovider.InstanceDeallocating, instance2.Status.State)
+			}
+		})
+	}
+}
+
+func TestWaitForStartInstance(t *testing.T) {
+	provider := newTestProvider(t)
+
+	expectedVMSSVMs := newTestVMSSVMList(3)
+	var instances []cloudprovider.Instance
+	for _, vm := range expectedVMSSVMs {
+		instances = append(instances, cloudprovider.Instance{
+			Id: azurePrefix + *vm.ID,
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceRunning,
+			},
+		})
+	}
+
+	asg := &ScaleSet{
+		manager:         provider.azureManager,
+		minSize:         1,
+		maxSize:         5,
+		InstanceCache:   InstanceCache{instanceCache: instances, instancesRefreshPeriod: defaultVmssInstancesRefreshPeriod},
+		scaleDownPolicy: deallocate.Deallocate,
+	}
+	asg.Name = testASG
+
+	t.Run("success: cache stays valid", func(t *testing.T) {
+		asg.instanceMutex.Lock()
+		asg.lastInstanceRefresh = time.Now()
+		asg.instanceMutex.Unlock()
+
+		poller := newFakeStartPoller(&fakeSuccessHandler[armcompute.VirtualMachineScaleSetsClientStartResponse]{})
+		asg.waitForStartInstance(poller, "0")
+
+		for _, vm := range asg.instanceCache {
+			assert.Equal(t, cloudprovider.InstanceRunning, vm.Status.State)
+		}
+		// Cache should NOT be invalidated on success
+		asg.instanceMutex.Lock()
+		assert.False(t, asg.lastInstanceRefresh.IsZero(), "instanceCache should not be invalidated on success")
+		asg.instanceMutex.Unlock()
+	})
+
+	t.Run("failure: cache is invalidated", func(t *testing.T) {
+		asg.instanceMutex.Lock()
+		asg.lastInstanceRefresh = time.Now()
+		asg.instanceMutex.Unlock()
+
+		timeBeforeCall := time.Now()
+		poller := newFakeStartPoller(&fakeErrorHandler[armcompute.VirtualMachineScaleSetsClientStartResponse]{
+			err: fmt.Errorf("some start error"),
+		})
+		asg.waitForStartInstance(poller, "0")
+
+		// On failure, instanceCache should be invalidated (lastInstanceRefresh set to the past)
+		asg.instanceMutex.Lock()
+		assert.True(t, asg.lastInstanceRefresh.Before(timeBeforeCall), "instanceCache should be invalidated on failure")
+		asg.instanceMutex.Unlock()
+	})
+}
+
+func TestWaitForDeallocateInstances(t *testing.T) {
+	provider := newTestProvider(t)
+
+	expectedVMSSVMs := newTestVMSSVMList(3)
+	var instances []cloudprovider.Instance
+	for _, vm := range expectedVMSSVMs {
+		instances = append(instances, cloudprovider.Instance{
+			Id: azurePrefix + *vm.ID,
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceDeallocating,
+			},
+		})
+	}
+
+	instanceRefs := []*azureRef{
+		{Name: azurePrefix + *expectedVMSSVMs[0].ID},
+		{Name: azurePrefix + *expectedVMSSVMs[1].ID},
+		{Name: azurePrefix + *expectedVMSSVMs[2].ID},
+	}
+
+	asg := &ScaleSet{
+		manager:         provider.azureManager,
+		minSize:         1,
+		maxSize:         5,
+		InstanceCache:   InstanceCache{instanceCache: instances, instancesRefreshPeriod: defaultVmssInstancesRefreshPeriod},
+		scaleDownPolicy: deallocate.Deallocate,
+	}
+	asg.Name = testASG
+
+	t.Run("success: instances set to deallocated", func(t *testing.T) {
+		// Reset states to Deallocating
+		for i := range asg.instanceCache {
+			asg.instanceCache[i].Status.State = cloudprovider.InstanceDeallocating
+		}
+		asg.instanceMutex.Lock()
+		asg.lastInstanceRefresh = time.Now()
+		asg.instanceMutex.Unlock()
+
+		poller := newFakeDeallocatePoller(&fakeSuccessHandler[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]{})
+		asg.waitForDeallocateInstances(poller, instanceRefs, []*string{})
+
+		for _, vm := range asg.instanceCache {
+			assert.Equal(t, cloudprovider.InstanceDeallocated, vm.Status.State)
+		}
+		// Cache should NOT be invalidated on success
+		asg.instanceMutex.Lock()
+		assert.False(t, asg.lastInstanceRefresh.IsZero(), "instanceCache should not be invalidated on success")
+		asg.instanceMutex.Unlock()
+	})
+
+	t.Run("success: instance started concurrently is not overwritten", func(t *testing.T) {
+		// Reset states to Deallocating (simulating in-flight deallocate)
+		for i := range asg.instanceCache {
+			asg.instanceCache[i].Status.State = cloudprovider.InstanceDeallocating
+		}
+		// Simulate a concurrent startInstance having set instance 1 to Running
+		// while the deallocate poller was in flight
+		asg.instanceCache[1].Status.State = cloudprovider.InstanceRunning
+
+		asg.instanceMutex.Lock()
+		asg.lastInstanceRefresh = time.Now()
+		asg.instanceMutex.Unlock()
+
+		poller := newFakeDeallocatePoller(&fakeSuccessHandler[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]{})
+		asg.waitForDeallocateInstances(poller, instanceRefs, []*string{})
+
+		// Instance 0 and 2 should transition to Deallocated
+		assert.Equal(t, cloudprovider.InstanceDeallocated, asg.instanceCache[0].Status.State)
+		assert.Equal(t, cloudprovider.InstanceDeallocated, asg.instanceCache[2].Status.State)
+		// Instance 1 should remain Running — the newer startInstance operation takes precedence
+		assert.Equal(t, cloudprovider.InstanceRunning, asg.instanceCache[1].Status.State)
+	})
+
+	t.Run("success: instance being deleted concurrently is not overwritten", func(t *testing.T) {
+		// Reset states to Deallocating
+		for i := range asg.instanceCache {
+			asg.instanceCache[i].Status.State = cloudprovider.InstanceDeallocating
+		}
+		// Simulate a concurrent DeleteInstances having set instance 2 to Deleting
+		asg.instanceCache[2].Status.State = cloudprovider.InstanceDeleting
+
+		asg.instanceMutex.Lock()
+		asg.lastInstanceRefresh = time.Now()
+		asg.instanceMutex.Unlock()
+
+		poller := newFakeDeallocatePoller(&fakeSuccessHandler[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]{})
+		asg.waitForDeallocateInstances(poller, instanceRefs, []*string{})
+
+		// Instance 0 and 1 should transition to Deallocated
+		assert.Equal(t, cloudprovider.InstanceDeallocated, asg.instanceCache[0].Status.State)
+		assert.Equal(t, cloudprovider.InstanceDeallocated, asg.instanceCache[1].Status.State)
+		// Instance 2 should remain Deleting
+		assert.Equal(t, cloudprovider.InstanceDeleting, asg.instanceCache[2].Status.State)
+	})
+
+	t.Run("failure: deallocate cache is invalidated", func(t *testing.T) {
+		// Reset states to Deallocating
+		for i := range asg.instanceCache {
+			asg.instanceCache[i].Status.State = cloudprovider.InstanceDeallocating
+		}
+		asg.instanceMutex.Lock()
+		asg.lastInstanceRefresh = time.Now()
+		asg.instanceMutex.Unlock()
+
+		timeBeforeCall := time.Now()
+		poller := newFakeDeallocatePoller(&fakeErrorHandler[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]{
+			err: fmt.Errorf("some deallocate error"),
+		})
+		asg.waitForDeallocateInstances(poller, instanceRefs, []*string{})
+
+		// On failure, instanceCache should be invalidated (lastInstanceRefresh set to the past)
+		asg.instanceMutex.Lock()
+		assert.True(t, asg.lastInstanceRefresh.Before(timeBeforeCall), "instanceCache should be invalidated on failure")
+		asg.instanceMutex.Unlock()
+
+		// States should NOT have been changed to Deallocated
+		for _, vm := range asg.instanceCache {
+			assert.Equal(t, cloudprovider.InstanceDeallocating, vm.Status.State)
+		}
+	})
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
@@ -197,6 +198,43 @@ func (scaleSet *ScaleSet) setInstanceStatusByProviderID(providerID string, statu
 	}
 }
 
+// setInstanceStatusIfNotSuperseded sets the status for an instance only if a newer concurrent
+// operation has not already transitioned it to a different state. This prevents async completion
+// goroutines (e.g., waitForDeallocateInstances) from blindly overwriting cache state that was
+// set by a more recent operation (e.g., startInstance).
+//
+// supersedingStates lists the states that indicate a newer operation has taken over — if the
+// instance is currently in any of these states, the update is skipped.
+func (scaleSet *ScaleSet) setInstanceStatusIfNotSuperseded(providerID string, status cloudprovider.InstanceStatus, supersedingStates []cloudprovider.InstanceState) {
+	scaleSet.instanceMutex.Lock()
+	defer scaleSet.instanceMutex.Unlock()
+
+	err := scaleSet.validateInstanceCacheWithoutLock()
+	if err != nil {
+		klog.Errorf("setInstanceStatusIfNotSuperseded: error validating instanceCache for providerID %s for "+
+			"scaleSet: %s, err: %v", providerID, scaleSet.Name, err)
+	}
+
+	for k, instance := range scaleSet.instanceCache {
+		if instance.Id == providerID {
+			if instance.Status != nil {
+				for _, s := range supersedingStates {
+					if instance.Status.State == s {
+						klog.V(3).Infof("setInstanceStatusIfNotSuperseded: skipping state update for %s "+
+							"in scaleSet %s: current state %v was set by a newer operation (target was %v)",
+							providerID, scaleSet.Name, instance.Status.State, status.State)
+						return
+					}
+				}
+			}
+			klog.V(3).Infof("setInstanceStatusIfNotSuperseded: setting instance state for %s for scaleSet "+
+				"%s to %d", instance.Id, scaleSet.Name, status.State)
+			scaleSet.instanceCache[k].Status = &status
+			break
+		}
+	}
+}
+
 // instanceStatusFromVM converts the VM provisioning state to cloudprovider.InstanceStatus.
 // Suggestion: reunify this with instanceStatusFromProvisioningStateAndPowerState() in azure_scale_set.go
 func (scaleSet *ScaleSet) instanceStatusFromVM(vm *armcompute.VirtualMachineScaleSetVM) *cloudprovider.InstanceStatus {
@@ -234,16 +272,30 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *armcompute.VirtualMachineScal
 		status.State = cloudprovider.InstanceCreating
 	case VMProvisioningStateFailed:
 		status.State = cloudprovider.InstanceRunning
-
-		klog.V(3).Infof("VM %s reports failed provisioning state with power state: %s, eligible for fast delete: %s", ptr.Deref(vm.ID, ""), powerState, strconv.FormatBool(scaleSet.enableFastDeleteOnFailedProvisioning))
-		if scaleSet.enableFastDeleteOnFailedProvisioning {
-			// Provisioning can fail both during instance creation or after the instance is running.
+		klog.V(3).Infof("VM %s reports failed provisioning state with power state: %s, scale down mode: %s, eligible for fast delete: %s", ptr.Deref(vm.ID, ""), powerState, scaleSet.scaleDownPolicy, strconv.FormatBool(scaleSet.enableFastDeleteOnFailedProvisioning))
+		if scaleSet.scaleDownPolicy == deallocate.Deallocate {
+			// Deallocate mode: detect failed-to-start VMs.
+			if !isRunningVmPowerState(powerState) {
+				// VM failed to start — remains deallocated or stopped.
+				// Signal as creation error to trigger backoff via handleInstanceCreationErrors.
+				// Failed VMs will be cleaned up by deleteCreatedNodesWithErrors, which for
+				// deallocate mode calls ForceDeleteNodes → deallocateInstances (returning
+				// the VM to a clean deallocated state for the next scale-up after backoff).
+				status.State = cloudprovider.InstanceCreating
+				status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "start-deallocated-failed",
+					ErrorMessage: "Failed to start deallocated VM",
+				}
+			}
+			// Running power state: VM started but may have extension errors.
+			// CSE error check below (enableDetailedCSEMessage) handles this case.
+		} else if scaleSet.enableFastDeleteOnFailedProvisioning {
+			// Delete mode: existing fast-delete path for failed provisioning.
 			// Per https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing#provisioning-states,
 			// ProvisioningState represents the most recent provisioning state, therefore only report
 			// InstanceCreating errors when the power state indicates the instance has not yet started running
 			if !isRunningVmPowerState(powerState) {
-				// This fast deletion relies on the fact that InstanceCreating + ErrorInfo will subsequently trigger a deletion.
-				// Could be revisited to rely on something more stable/explicit.
 				status.State = cloudprovider.InstanceCreating
 				status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
 					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
@@ -261,7 +313,7 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *armcompute.VirtualMachineScal
 	// Add vmssCSE Provisioning Failed Message in error info body for vmssCSE Extensions if enableDetailedCSEMessage is true
 	if scaleSet.enableDetailedCSEMessage && vm.Properties.InstanceView != nil {
 		if err, failed := scaleSet.cseErrors(vm.Properties.InstanceView.Extensions); failed {
-			klog.V(3).Infof("VM %s reports CSE failure: %v, with provisioning state %s, power state %s", ptr.Deref(vm.ID, ""), err, ptr.Deref(vm.Properties.ProvisioningState, ""), powerState)
+			klog.V(3).Infof("VM %s reports CSE failure: %v, with provisioning state %s, power state %s, scale down mode: %s", ptr.Deref(vm.ID, ""), err, ptr.Deref(vm.Properties.ProvisioningState, ""), powerState, scaleSet.scaleDownPolicy)
 			status.State = cloudprovider.InstanceCreating
 			errorInfo := &cloudprovider.InstanceErrorInfo{
 				ErrorClass:   cloudprovider.OtherErrorClass,
@@ -272,5 +324,23 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *armcompute.VirtualMachineScal
 		}
 	}
 
+	// now check power state
+	if vm.Properties.InstanceView != nil && vm.Properties.InstanceView.Statuses != nil {
+		statuses := vm.Properties.InstanceView.Statuses
+
+		for _, s := range statuses {
+			state := ptr.Deref(s.Code, "")
+			// set the state to deallocated/deallocating based on their running state if provisioning is succeeded.
+			// This is to avoid the weird states with Failed VMs which can fail all API calls.
+			// This information is used to build instanceCache in CA.
+			if ptr.Deref(vm.Properties.ProvisioningState, "") == string(armcompute.GalleryProvisioningStateSucceeded) {
+				if powerStateDeallocated(state) {
+					status.State = cloudprovider.InstanceDeallocated
+				} else if powerStateDeallocating(state) {
+					status.State = cloudprovider.InstanceDeallocating
+				}
+			}
+		}
+	}
 	return status
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_deallocate_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_deallocate_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+)
+
+// TestInstanceStatusFromVMErrorCodeByScaleDownModeSelfHosted verifies error codes
+// for self-hosted clusters with enableFastDeleteOnFailedProvisioning=false.
+// In this case, only deallocate mode generates error codes; delete mode returns InstanceRunning.
+func TestInstanceStatusFromVMErrorCodeByScaleDownModeSelfHosted(t *testing.T) {
+	tests := map[string]struct {
+		scaleDownPolicy   deallocate.ScaleDownPolicy
+		expectedState     cloudprovider.InstanceState
+		expectedErrorCode string
+	}{
+		"deallocate mode still gets start-deallocated-failed without fast delete": {
+			scaleDownPolicy:   deallocate.Deallocate,
+			expectedState:     cloudprovider.InstanceCreating,
+			expectedErrorCode: "start-deallocated-failed",
+		},
+		"delete mode falls back to InstanceRunning without fast delete": {
+			scaleDownPolicy:   deallocate.Delete,
+			expectedState:     cloudprovider.InstanceRunning,
+			expectedErrorCode: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			provider := newTestProvider(t)
+			scaleSet := &ScaleSet{
+				azureRef:                             azureRef{Name: "testScaleSet"},
+				manager:                              provider.azureManager,
+				minSize:                              1,
+				maxSize:                              5,
+				enableFastDeleteOnFailedProvisioning: false, // self-hosted: fast delete disabled
+				scaleDownPolicy:                      tt.scaleDownPolicy,
+			}
+
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopped)
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, tt.expectedState, status.State)
+			if tt.expectedErrorCode != "" {
+				assert.NotNil(t, status.ErrorInfo)
+				assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+				assert.Equal(t, tt.expectedErrorCode, status.ErrorInfo.ErrorCode)
+			} else {
+				// In delete mode with fast delete off, no error info.
+				assert.Nil(t, status.ErrorInfo)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache_test.go
@@ -18,12 +18,20 @@ package azure
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetclient/mock_virtualmachinescalesetclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/mock_virtualmachinescalesetvmclient"
 )
 
 func testGetInstanceCacheWithStates(t *testing.T, vms []*armcompute.VirtualMachineScaleSetVM,
@@ -160,6 +168,646 @@ func TestInstanceStatusFromVM(t *testing.T) {
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
 			assert.NotNil(t, status.ErrorInfo)
+		})
+	})
+}
+
+// Suggestion: simplify all unit tests below here; looks like it is trying to test multiple things (e.g., state handling, cache, deallocate mode) at the same time
+var (
+	ctrl                                 *gomock.Controller
+	currentTime, expiredTime             time.Time
+	provider                             *AzureCloudProvider
+	scaleSet                             *ScaleSet
+	mockVMSSVMClient                     *mock_virtualmachinescalesetvmclient.MockInterface
+	expectedVMSSVMs                      []*armcompute.VirtualMachineScaleSetVM
+	expectedStates                       []cloudprovider.InstanceState
+	instanceCache, expectedInstanceCache []cloudprovider.Instance
+)
+
+func newTestScaleSetDeallocateMode(manager *AzureManager, name string) *ScaleSet {
+	return &ScaleSet{
+		azureRef: azureRef{
+			Name: name,
+		},
+		manager:           manager,
+		minSize:           1,
+		maxSize:           5,
+		enableForceDelete: manager.config.EnableForceDelete,
+		scaleDownPolicy:   deallocate.Deallocate,
+	}
+}
+
+func newTestScaleSetDeallocateModeWithFastDelete(manager *AzureManager, name string) *ScaleSet {
+	return &ScaleSet{
+		azureRef: azureRef{
+			Name: name,
+		},
+		manager:                              manager,
+		minSize:                              1,
+		maxSize:                              5,
+		enableForceDelete:                    manager.config.EnableForceDelete,
+		enableFastDeleteOnFailedProvisioning: true,
+		scaleDownPolicy:                      deallocate.Deallocate,
+	}
+}
+
+func TestInvalidateInstanceCache(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+
+	scaleSet.invalidateInstanceCache()
+	assert.Lessf(t, scaleSet.lastInstanceRefresh, currentTime, "lastInstanceRefresh should be less than current"+
+		"time as instanceCache is invalidated")
+}
+
+// TestValidateInstanceCache tests only with orchestrationMode = Uniform
+func TestValidateInstanceCache(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+
+	// t1 - expect no update to instanceCache because timer has not yet expired
+	err := scaleSet.validateInstanceCache()
+	assert.NoErrorf(t, err, "err is not expected when validating instanceCache with a fresh cache")
+
+	TestBeforeEachInstanceCacheResetNeededHelper(t)
+
+	// t2 - expect update happens because instanceCache is invalidated without deallocate mode and enableCSE
+	err = scaleSet.validateInstanceCache()
+	assert.NoError(t, err)
+	assert.Equalf(t, len(expectedVMSSVMs), len(scaleSet.instanceCache), "instanceCache must be updated")
+	assert.Greaterf(t, scaleSet.lastInstanceRefresh, expiredTime, "after refresh, instanceCache should have updated"+
+		"lastInstanceRefresh")
+
+	// t3 - throttling on get call - cache is not update but refresh time is updated
+	instanceCacheLen := len(scaleSet.instanceCache)
+	expiredTime = scaleSet.lastInstanceRefresh.Add(-1 * scaleSet.instancesRefreshPeriod)
+	scaleSet.lastInstanceRefresh = expiredTime
+	throttledError := &azcore.ResponseError{
+		StatusCode:  http.StatusTooManyRequests,
+		RawResponse: &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}},
+	}
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(
+		[]*armcompute.VirtualMachineScaleSetVM{}, throttledError).Times(1)
+	err = scaleSet.validateInstanceCache()
+	assert.NoError(t, err)
+	assert.Equalf(t, instanceCacheLen, len(scaleSet.instanceCache), "instanceCache must not be updated")
+	assert.Greaterf(t, scaleSet.lastInstanceRefresh, expiredTime, "lastInstanceRefresh must be updated even if the "+
+		"instanceCache is not updated")
+}
+
+func TestGetInstanceByProviderID(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+
+	// t1 - cache is not stale - instance exists in the instanceCache
+	reqProviderID := azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)
+	actualInstance, found, err := scaleSet.getInstanceByProviderID(reqProviderID)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, instanceCache[0], actualInstance)
+
+	TestBeforeEachInstanceCacheResetNeededHelper(t)
+
+	// t2 - cache is stale - instance exists in the instanceCache
+	reqProviderID = azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 1)
+	actualInstance, found, err = scaleSet.getInstanceByProviderID(reqProviderID)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, expectedInstanceCache[1].Id, actualInstance.Id)
+	assert.Equal(t, expectedInstanceCache[1].Status.State, actualInstance.Status.State)
+
+	// t3 - cache is not stale and instance doesn't exist in the instanceCache
+	scaleSet.lastInstanceRefresh = time.Now()
+	reqProviderID = azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)
+	actualInstance, found, err = scaleSet.getInstanceByProviderID(reqProviderID)
+	assert.NoError(t, err)
+	assert.False(t, found)
+	assert.Empty(t, actualInstance)
+}
+
+func TestGetInstancesByState(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+	scaleSet.scaleDownPolicy = deallocate.Deallocate // Suggestion: (also apply to similar entires) use TestScaleSetDellocateMode; right now that is abstracted behind TestBeforeEachNoInstanceCacheResetNeededHelper
+
+	// t1 cache is not stale - instance with given state exists in the instanceCache
+	actualInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceDeallocated)
+	assert.NoError(t, err)
+	assert.Equal(t, instanceCache, actualInstances)
+
+	TestBeforeEachInstanceCacheResetNeededHelper(t)
+	scaleSet.scaleDownPolicy = deallocate.Deallocate
+
+	// t2 - cache is stale - instance with given state exists in the instanceCache
+	// VM[0] has ProvisioningState=Failed + no InstanceView (defaults to running power state)
+	// In deallocate mode, running VMs with failed provisioning are treated as InstanceRunning
+	actualInstances, err = scaleSet.getInstancesByState(cloudprovider.InstanceRunning)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(actualInstances)) // there should be only one instance with running state (was InstanceFailed before fix)
+	assert.Equal(t, expectedInstanceCache[0].Id, actualInstances[0].Id)
+	assert.Equal(t, expectedInstanceCache[0].Status.State, actualInstances[0].Status.State)
+
+	// t3 - cache is not stale and instance with given state doesn't exist in the instanceCache
+	scaleSet.lastInstanceRefresh = time.Now()
+	actualInstances, err = scaleSet.getInstancesByState(cloudprovider.InstanceDeallocating)
+	assert.NoError(t, err)
+	assert.Empty(t, actualInstances)
+}
+
+func TestGetInstanceCacheSize(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+
+	// t1 - cache is not stale - cache will not update and return size of 1
+	actualSize, err := scaleSet.getInstanceCacheSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, int(actualSize))
+
+	TestBeforeEachInstanceCacheResetNeededHelper(t)
+
+	// t2 - cache is stale - update will return size of 2
+	actualSize, err = scaleSet.getInstanceCacheSize()
+	assert.NoError(t, err)
+	assert.Equal(t, len(expectedInstanceCache), int(actualSize))
+}
+
+func TestSetInstanceStatusByProviderID(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+	scaleSet.scaleDownPolicy = deallocate.Deallocate
+
+	// t1 - cache is not stale - instance exists in the instanceCache
+	providerID := azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)
+	status := cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning}
+	scaleSet.setInstanceStatusByProviderID(providerID, status)
+	actualInstance, found, err := scaleSet.getInstanceByProviderID(providerID)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, cloudprovider.InstanceRunning, actualInstance.Status.State)
+
+	TestBeforeEachInstanceCacheResetNeededHelper(t)
+	scaleSet.scaleDownPolicy = deallocate.Deallocate
+
+	// t2 - cache is stale - expectInstanceCache update, set for providerID=2 will not be added to the instanceCache because
+	// it doesn't exist in the cache. GetScaleSetVms() will have not introduced instance with providerID=2
+	providerID = azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 2)
+	status = cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting}
+	scaleSet.setInstanceStatusByProviderID(providerID, status) // it will not set for providerID=2 as it is not already present in the cache
+	actualInstances, err := scaleSet.getInstancesByState(cloudprovider.InstanceDeleting)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(actualInstances))
+}
+
+func TestSetInstanceStatusIfNotSuperseded(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+	scaleSet.scaleDownPolicy = deallocate.Deallocate
+
+	providerID := azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)
+
+	t.Run("updates state when not superseded", func(t *testing.T) {
+		// Instance starts as Deallocated, target is Deallocated — no superseding states match
+		scaleSet.setInstanceStatusIfNotSuperseded(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+			[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		actual, found, err := scaleSet.getInstanceByProviderID(providerID)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, cloudprovider.InstanceDeallocated, actual.Status.State)
+	})
+
+	t.Run("skips update when current state is in superseding list", func(t *testing.T) {
+		// Set instance to Running (simulating concurrent startInstance)
+		scaleSet.setInstanceStatusByProviderID(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning})
+
+		// Try to set to Deallocated — should be skipped because Running is superseding
+		scaleSet.setInstanceStatusIfNotSuperseded(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+			[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		actual, found, err := scaleSet.getInstanceByProviderID(providerID)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, cloudprovider.InstanceRunning, actual.Status.State)
+	})
+
+	t.Run("skips update when current state is Deleting", func(t *testing.T) {
+		scaleSet.setInstanceStatusByProviderID(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting})
+
+		scaleSet.setInstanceStatusIfNotSuperseded(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+			[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		actual, found, err := scaleSet.getInstanceByProviderID(providerID)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, cloudprovider.InstanceDeleting, actual.Status.State)
+	})
+
+	t.Run("updates when current state is not in superseding list", func(t *testing.T) {
+		// Set to Deallocating — not in the superseding list [Running, Deleting]
+		scaleSet.setInstanceStatusByProviderID(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocating})
+
+		scaleSet.setInstanceStatusIfNotSuperseded(providerID,
+			cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated},
+			[]cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeleting})
+		actual, found, err := scaleSet.getInstanceByProviderID(providerID)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, cloudprovider.InstanceDeallocated, actual.Status.State)
+	})
+}
+
+// beforeEachNoInstanceCacheResetNeededHelper has 1 instance in the instanceCache with state = deallocated.
+func TestBeforeEachNoInstanceCacheResetNeededHelper(t *testing.T) {
+	ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider = newTestProvider(t)
+	scaleSet = newTestScaleSet(provider.azureManager, testASG)
+	scaleSet.instancesRefreshPeriod = defaultVmssInstancesRefreshPeriod
+
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", armcompute.OrchestrationModeUniform)
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+
+	registered := provider.azureManager.RegisterNodeGroup(
+		scaleSet)
+	provider.azureManager.explicitlyConfigured[testASG] = true
+	assert.True(t, registered)
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	currentTime = time.Now()
+	scaleSet.lastInstanceRefresh = currentTime
+	expectedVMSSVMs = newTestVMSSVMList(1)
+	expectedStates = []cloudprovider.InstanceState{cloudprovider.InstanceDeallocated}
+	instanceCache = testGetInstanceCacheWithStates(t, expectedVMSSVMs, expectedStates)
+	scaleSet.instanceCache = instanceCache
+}
+
+// beforeEachInstanceCacheResetNeededHelper has 1 instance in the instanceCache with state = failed, deallocated
+func TestBeforeEachInstanceCacheResetNeededHelper(t *testing.T) {
+	expiredTime = scaleSet.lastInstanceRefresh.Add(-1 * scaleSet.instancesRefreshPeriod)
+	scaleSet.lastInstanceRefresh = expiredTime
+	mockVMSSVMClient = mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+	expectedVMSSVMs = newTestVMSSVMList(2)
+	expectedVMSSVMs[0].Properties.ProvisioningState = ptr.To(string(armcompute.GalleryProvisioningStateFailed))
+	expectedVMSSVMs[1].Properties.ProvisioningState = ptr.To(string(armcompute.GalleryProvisioningStateSucceeded))
+	expectedVMSSVMs[1].Properties.InstanceView = &armcompute.VirtualMachineScaleSetVMInstanceView{
+		Statuses: []*armcompute.InstanceViewStatus{
+			{Code: ptr.To(vmPowerStateDeallocated)},
+		},
+	}
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(
+		expectedVMSSVMs, nil)
+	expectedStates = []cloudprovider.InstanceState{cloudprovider.InstanceRunning, cloudprovider.InstanceDeallocated}
+	expectedInstanceCache = testGetInstanceCacheWithStates(t, expectedVMSSVMs, expectedStates)
+}
+
+func TestInstanceStatusFromVMEnableFastDeleteOnFailedProvisioning(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+
+	scaleSet.scaleDownPolicy = deallocate.Deallocate
+	// Disabled EnableFastDelete, deallocate mode, running power state
+	// Running VMs in deallocate mode default to InstanceRunning (CSE error check handles broken VMs)
+	vm := &armcompute.VirtualMachineScaleSetVM{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To(string(armcompute.GalleryProvisioningStateFailed)),
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
+					{Code: ptr.To(vmPowerStateRunning)},
+				},
+			},
+		},
+	}
+	status := scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+
+	// Enabled EnableFastDelete, deallocate mode, running power state
+	// Running VMs still get InstanceRunning — fast-delete doesn't apply in deallocate mode for running VMs
+	scaleSet.enableFastDeleteOnFailedProvisioning = true
+	vm = &armcompute.VirtualMachineScaleSetVM{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To(string(armcompute.GalleryProvisioningStateFailed)),
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
+					{Code: ptr.To(vmPowerStateRunning)},
+				},
+			},
+		},
+	}
+	status = scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+	scaleSet.enableFastDeleteOnFailedProvisioning = false
+
+	// Enabled EnableFastDelete, deallocate mode, not running power state
+	// Non-running VMs in deallocate mode trigger backoff (InstanceCreating + ErrorInfo)
+	scaleSet.enableFastDeleteOnFailedProvisioning = true
+	vm = &armcompute.VirtualMachineScaleSetVM{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To(string(armcompute.GalleryProvisioningStateFailed)),
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
+					{Code: ptr.To(vmPowerStateStopped)},
+				},
+			},
+		},
+	}
+	status = scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotNil(t, status.ErrorInfo)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+	assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
+	scaleSet.enableFastDeleteOnFailedProvisioning = false
+
+	scaleSet.scaleDownPolicy = deallocate.Delete
+	// Disabled EnableFastDelete, delete mode, running power state
+	vm = &armcompute.VirtualMachineScaleSetVM{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To(string(armcompute.GalleryProvisioningStateFailed)),
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
+					{Code: ptr.To(vmPowerStateRunning)},
+				},
+			},
+		},
+	}
+	status = scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+
+	// Enabled EnableFastDelete, delete mode, running power state
+	scaleSet.enableFastDeleteOnFailedProvisioning = true
+	vm = &armcompute.VirtualMachineScaleSetVM{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To(string(armcompute.GalleryProvisioningStateFailed)),
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
+					{Code: ptr.To(vmPowerStateRunning)},
+				},
+			},
+		},
+	}
+	status = scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+	scaleSet.enableFastDeleteOnFailedProvisioning = false
+
+	// Enabled EnableFastDelete, delete mode, not running power state
+	scaleSet.enableFastDeleteOnFailedProvisioning = true
+	vm = &armcompute.VirtualMachineScaleSetVM{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To(string(armcompute.GalleryProvisioningStateFailed)),
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
+					{Code: ptr.To(vmPowerStateStopped)},
+				},
+			},
+		},
+	}
+	status = scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotEmpty(t, status.ErrorInfo)
+	scaleSet.enableFastDeleteOnFailedProvisioning = false
+}
+
+func TestInstanceStatusFromVMEnableFastDeleteOnCSEFailure(t *testing.T) {
+	TestBeforeEachNoInstanceCacheResetNeededHelper(t)
+
+	// Enabled EnableFastDelete, delete mode, not running power state
+	scaleSet.enableFastDeleteOnFailedProvisioning = true
+	scaleSet.enableDetailedCSEMessage = true
+	vm := &armcompute.VirtualMachineScaleSetVM{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To(string(armcompute.GalleryProvisioningStateFailed)),
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
+					{Code: ptr.To(vmPowerStateStopped)},
+				},
+				Extensions: []*armcompute.VirtualMachineExtensionInstanceView{
+					{
+						Name: ptr.To(vmssCSEExtensionName),
+						Statuses: []*armcompute.InstanceViewStatus{
+							{
+								Level:   ptr.To(armcompute.StatusLevelTypesError),
+								Code:    ptr.To(vmssExtensionProvisioningFailed),
+								Message: ptr.To("Custom Script Extension failed to provision"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	status := scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotEmpty(t, status.ErrorInfo)
+	assert.Equal(t, cloudprovider.OtherErrorClass, status.ErrorInfo.ErrorClass)
+	assert.Equal(t, vmssExtensionProvisioningFailed, status.ErrorInfo.ErrorCode)
+	scaleSet.enableFastDeleteOnFailedProvisioning = false
+}
+
+func TestInstanceStatusFromVMDeallocateModeCSEFailure(t *testing.T) {
+	// Deallocate mode + running VM + Custom Script Extension (CSE) error: the CSE check should override
+	// InstanceRunning with InstanceCreating + OtherErrorClass. This is the main detection path for VMs that
+	// started but have broken extensions (Gap 2 from the tail-side error handling design).
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSetDeallocateModeWithFastDelete(provider.azureManager, "testScaleSet")
+	scaleSet.enableDetailedCSEMessage = true
+
+	vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateRunning)
+	vm.Properties.InstanceView.Extensions = []*armcompute.VirtualMachineExtensionInstanceView{
+		{
+			Name: ptr.To(vmssCSEExtensionName),
+			Statuses: []*armcompute.InstanceViewStatus{
+				{
+					Level:   ptr.To(armcompute.StatusLevelTypesError),
+					Code:    ptr.To(vmssExtensionProvisioningFailed),
+					Message: ptr.To("Custom Script Extension failed to provision"),
+				},
+			},
+		},
+	}
+
+	status := scaleSet.instanceStatusFromVM(vm)
+	assert.NotNil(t, status)
+	assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+	assert.NotNil(t, status.ErrorInfo)
+	assert.Equal(t, cloudprovider.OtherErrorClass, status.ErrorInfo.ErrorClass)
+	assert.Equal(t, vmssExtensionProvisioningFailed, status.ErrorInfo.ErrorCode)
+}
+
+func TestInstanceStatusFromVMErrorCodeByScaleDownMode(t *testing.T) {
+	// Verify that deallocate mode and delete mode get distinct error codes
+	// under identical conditions (Failed + non-running + enableFastDelete).
+	tests := map[string]struct {
+		scaleDownPolicy   deallocate.ScaleDownPolicy
+		expectedErrorCode string
+	}{
+		"deallocate mode gets start-deallocated-failed": {
+			scaleDownPolicy:   deallocate.Deallocate,
+			expectedErrorCode: "start-deallocated-failed",
+		},
+		"delete mode gets provisioning-state-failed": {
+			scaleDownPolicy:   deallocate.Delete,
+			expectedErrorCode: "provisioning-state-failed",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			provider := newTestProvider(t)
+			scaleSet := &ScaleSet{
+				azureRef:                             azureRef{Name: "testScaleSet"},
+				manager:                              provider.azureManager,
+				minSize:                              1,
+				maxSize:                              5,
+				enableFastDeleteOnFailedProvisioning: true,
+				scaleDownPolicy:                      tt.scaleDownPolicy,
+			}
+
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopped)
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, status.ErrorInfo.ErrorClass)
+			assert.Equal(t, tt.expectedErrorCode, status.ErrorInfo.ErrorCode)
+		})
+	}
+}
+
+func TestInstanceStatusFromVMDeallocateMode(t *testing.T) {
+	t.Run("fast delete enablement = false", func(t *testing.T) {
+		provider := newTestProvider(t)
+		scaleSet := newTestScaleSetDeallocateMode(provider.azureManager, "testScaleSet")
+
+		t.Run("provisioning state = failed, power state = starting", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStarting)
+			status := scaleSet.instanceStatusFromVM(vm)
+			assert.NotNil(t, status)
+			// Without enableFastDeleteOnFailedProvisioning, all failed VMs default to InstanceRunning
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateRunning)
+			status := scaleSet.instanceStatusFromVM(vm)
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopping)
+			status := scaleSet.instanceStatusFromVM(vm)
+			assert.NotNil(t, status)
+			// Stopping is not a running power state — triggers backoff even without enableFastDelete
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
+		})
+
+		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopped)
+			status := scaleSet.instanceStatusFromVM(vm)
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
+		})
+
+		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateDeallocated)
+			status := scaleSet.instanceStatusFromVM(vm)
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
+		})
+
+		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateUnknown)
+			status := scaleSet.instanceStatusFromVM(vm)
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
+		})
+	})
+
+	t.Run("fast delete enablement = true", func(t *testing.T) {
+		provider := newTestProvider(t)
+		scaleSet := newTestScaleSetDeallocateModeWithFastDelete(provider.azureManager, "testScaleSet")
+
+		t.Run("provisioning state = failed, power state = starting", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStarting)
+
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			// Starting is a running power state — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateRunning)
+
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			// Running VM with failed provisioning — treated as running
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopping)
+
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			// Stopping is not a running power state — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
+		})
+
+		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateStopped)
+
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			// Stopped is not running — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
+		})
+
+		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateDeallocated)
+
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			// Deallocated VM that failed to start — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
+		})
+
+		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
+			vm := newVMObjectWithState(string(armcompute.GalleryProvisioningStateFailed), vmPowerStateUnknown)
+
+			status := scaleSet.instanceStatusFromVM(vm)
+
+			assert.NotNil(t, status)
+			// Unknown power state (not running) — triggers backoff
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+			assert.Equal(t, "start-deallocated-failed", status.ErrorInfo.ErrorCode)
 		})
 	})
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -33,6 +33,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachineclient/mock_virtualmachineclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetclient/mock_virtualmachinescalesetclient"
@@ -271,6 +272,39 @@ func TestScaleSetTargetSizeReturnsErrorForCachedNegativeSize(t *testing.T) {
 	assert.Equal(t, -1, size)
 }
 
+// TestScaleSetTargetSizeReturnsErrorForNegativeDeallocateAdjustedSize verifies the
+// deallocate-mode guard in getScaleSetSize: when the deallocated/deallocating count
+// (from the instance cache) exceeds the reported VMSS capacity — only possible when the
+// caches are inconsistent, e.g. instances removed out-of-band — the subtraction would go
+// negative, and we surface an error instead of publishing a negative target size.
+func TestScaleSetTargetSizeReturnsErrorForNegativeDeallocateAdjustedSize(t *testing.T) {
+	provider := newTestProvider(t)
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	scaleSet := newTestScaleSetDeallocateMode(provider.azureManager, testASG)
+	// Pin a valid reported capacity of 3 (avoid a live size refresh).
+	scaleSet.curSize = 3
+	scaleSet.lastSizeRefresh = time.Now()
+	scaleSet.sizeRefreshPeriod = time.Hour
+
+	// Seed the instance cache with more deallocated instances (5) than the reported
+	// capacity (3), simulating a stale cache after instances were removed out-of-band.
+	scaleSet.instanceCache = []cloudprovider.Instance{
+		{Id: "0", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+		{Id: "1", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+		{Id: "2", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+		{Id: "3", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+		{Id: "4", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeallocated}},
+	}
+	scaleSet.lastInstanceRefresh = time.Now()
+	scaleSet.instancesRefreshPeriod = time.Hour
+
+	size, err := scaleSet.TargetSize()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "deallocated/deallocating instances is negative")
+	assert.Equal(t, -1, size)
+}
 func TestScaleSetIncreaseSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -703,6 +737,53 @@ func TestScaleSetAtomicIncreaseSizePollerFailure(t *testing.T) {
 
 // TestIncreaseSizeOnVMProvisioningFailed has been tweeked only for Uniform Orchestration mode.
 // If ProvisioningState == failed and power state is not running, Status.State == InstanceCreating with errorInfo populated.
+func TestScaleSetAtomicIncreaseSizeDeallocateNotImplemented(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", armcompute.OrchestrationModeUniform)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	provider := newTestProvider(t)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	// No BeginCreateOrUpdate call should be made for deallocate policy.
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
+
+	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	ss := &ScaleSet{
+		azureRef:        azureRef{Name: testASG},
+		manager:         provider.azureManager,
+		minSize:         1,
+		maxSize:         5,
+		scaleDownPolicy: deallocate.Deallocate,
+	}
+	registered := provider.azureManager.RegisterNodeGroup(ss)
+	assert.True(t, registered)
+
+	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
+	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+
+	// Target size should remain unchanged (3).
+	targetSize, err := provider.NodeGroups()[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+}
+
 func TestScaleSetIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
 	testCases := map[string]struct {
 		expectInstanceRunning    bool
@@ -2581,6 +2662,70 @@ func TestScaleSetETagRetrySkippedWhenAlreadyAtTarget(t *testing.T) {
 	assert.Equal(t, 1, putCalls, "expected no second PUT when VMSS already at target")
 }
 
+// TestScaleSetETagRetryInvalidatesInstanceCache verifies that after an ETag precondition
+// refresh, the instance cache is invalidated so a stale deallocated/deallocating count is
+// not reused. In deallocate mode getScaleSetSize subtracts the deallocated instance count
+// (read from the instance cache) from the reported capacity; if a concurrent writer removed
+// instances out-of-band (the case ETag guards), the refreshed VMSS carries fresh capacity
+// but the instance cache would still hold the pre-change count, yielding an incorrect
+// (potentially negative) target size. The refresh must therefore mark the instance cache
+// stale so it is recomputed from fresh Azure state.
+func TestScaleSetETagRetryInvalidatesInstanceCache(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-dealloc-invalidate"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	// CA's cached view: stale ETag, capacity 3.
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name:       ptr.To(vmssName),
+		SKU:        &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+		Etag:       ptr.To(`W/"stale"`),
+	})
+
+	// The refresh GET returns a fresh VMSS already at/above the desired target so the retry
+	// takes the skip path (GET only, no second PUT). The cache invalidation runs regardless.
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name:       ptr.To(vmssName),
+			SKU:        &armcompute.SKU{Capacity: ptr.To[int64](5)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+			Etag:       ptr.To(`W/"fresh"`),
+		}, nil).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	scaleSet := newTestScaleSetDeallocateMode(manager, vmssName)
+	scaleSet.instancesRefreshPeriod = 10 * time.Minute
+	// Mark the instance cache as freshly refreshed so we can observe the invalidation.
+	scaleSet.lastInstanceRefresh = time.Now()
+	assert.True(t, scaleSet.lastInstanceRefresh.Add(scaleSet.instancesRefreshPeriod).After(time.Now()),
+		"precondition: instance cache should start valid")
+
+	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
+	defer cancel()
+
+	fresh, poller, err := scaleSet.retryCreateOrUpdateWithFreshETag(ctx, 4)
+	assert.NoError(t, err)
+	assert.Nil(t, poller, "already-at-target refresh should skip the retry PUT")
+	if assert.NotNil(t, fresh) && assert.NotNil(t, fresh.SKU) && assert.NotNil(t, fresh.SKU.Capacity) {
+		assert.Equal(t, int64(5), *fresh.SKU.Capacity)
+	}
+
+	// The instance cache must now be considered stale, forcing a fresh recompute of the
+	// deallocated/deallocating count on the next getScaleSetSize.
+	assert.False(t, scaleSet.lastInstanceRefresh.Add(scaleSet.instancesRefreshPeriod).After(time.Now()),
+		"ETag refresh should invalidate the instance cache")
+}
+
 // TestScaleSetETagReconcilesConcurrentWriter exercises the core scenario ETag mode is
 // meant to protect: another writer mutates the VMSS between CA's read and its write.
 // Using a mock that enforces optimistic concurrency like the real API, CA's first PUT
@@ -2995,4 +3140,93 @@ func TestETagConcurrentAccessNoDataRace(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+// TestForceDeleteNodesDeallocateMode verifies that ForceDeleteNodes routes to
+// deallocateInstances (BeginDeallocate) for deallocate-mode groups, and to
+// DeleteInstances (BeginDeleteInstances) for delete-mode groups.
+func TestForceDeleteNodesDeallocateMode(t *testing.T) {
+	tests := map[string]struct {
+		scaleDownPolicy       deallocate.ScaleDownPolicy
+		expectDeallocate      bool
+		expectDeleteInstances bool
+	}{
+		"deallocate mode routes to deallocateInstances": {
+			scaleDownPolicy:       deallocate.Deallocate,
+			expectDeallocate:      true,
+			expectDeleteInstances: false,
+		},
+		"delete mode routes to DeleteInstances": {
+			scaleDownPolicy:       deallocate.Delete,
+			expectDeallocate:      false,
+			expectDeleteInstances: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			vmssName := "test-asg"
+			var vmssCapacity int64 = 3
+
+			expectedVMSSVMs := newTestVMSSVMList(3)
+			expectedVMs := newTestVMList(3)
+
+			manager := newTestAzureManager(t)
+			manager.config.EnableForceDelete = true
+			expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", armcompute.OrchestrationModeUniform)
+
+			mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).Times(2)
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+			mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+			if tc.expectDeallocate {
+				mockDeleteClient.EXPECT().BeginDeallocate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+			}
+			if tc.expectDeleteInstances {
+				mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+			}
+			manager.azClient.vmssClientForDelete = mockDeleteClient
+
+			mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+			mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+
+			err := manager.forceRefresh()
+			assert.NoError(t, err)
+
+			resourceLimiter := cloudprovider.NewResourceLimiter(
+				map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+				map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+			provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+			assert.NoError(t, err)
+
+			scaleSet := newTestScaleSet(manager, vmssName)
+			scaleSet.scaleDownPolicy = tc.scaleDownPolicy
+			registered := manager.RegisterNodeGroup(scaleSet)
+			manager.explicitlyConfigured[vmssName] = true
+			assert.True(t, registered)
+
+			err = manager.forceRefresh()
+			assert.NoError(t, err)
+
+			ss, ok := provider.NodeGroups()[0].(*ScaleSet)
+			assert.True(t, ok)
+			ss.scaleDownPolicy = tc.scaleDownPolicy
+
+			nodesToDelete := []*apiv1.Node{
+				newApiNode(armcompute.OrchestrationModeUniform, 0),
+			}
+
+			err = ss.ForceDeleteNodes(nodesToDelete)
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -666,6 +666,16 @@ func vmPowerStateFromStatuses(statuses []*armcompute.InstanceViewStatus) string 
 	return vmPowerStateUnknown
 }
 
+func powerStateDeallocating(state string) bool {
+	return powerStateExpectedMatchesActual(vmPowerStateDeallocating, state)
+}
+func powerStateDeallocated(state string) bool {
+	return powerStateExpectedMatchesActual(vmPowerStateDeallocated, state)
+}
+func powerStateExpectedMatchesActual(expected, actual string) bool {
+	return strings.EqualFold(actual, expected)
+}
+
 // strconv.ParseInt, but for int
 func parseInt32(s string, base int) (int, error) {
 	val, err := strconv.ParseInt(s, base, 32)

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -48,6 +48,9 @@ type VMPool struct {
 
 	minSize int
 	maxSize int
+
+	labels map[string]string
+	taints string
 }
 
 // NewVMPool creates a new VMPool - a pool of standalone VMs of a single size.
@@ -65,6 +68,8 @@ func NewVMPool(spec *dynamic.NodeGroupSpec, am *AzureManager, agentPoolName stri
 		agentPoolName: agentPoolName,
 		minSize:       spec.MinSize,
 		maxSize:       spec.MaxSize,
+		labels:        spec.Labels,
+		taints:        spec.Taints,
 	}
 	return nodepool, nil
 }
@@ -490,9 +495,8 @@ func (vmPool *VMPool) TemplateNodeInfo() (*framework.NodeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	inputLabels := map[string]string{}
-	inputTaints := ""
-	template, err := buildNodeTemplateFromVMPool(ap, vmPool.manager.config.Location, vmPool.sku, inputLabels, inputTaints)
+
+	template, err := buildNodeTemplateFromVMPool(ap, vmPool.manager.config.Location, vmPool.sku, vmPool.labels, vmPool.taints)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +506,6 @@ func (vmPool *VMPool) TemplateNodeInfo() (*framework.NodeInfo, error) {
 	}
 
 	nodeInfo := framework.NewNodeInfo(node, nil, framework.NewPodInfo(cloudprovider.BuildKubeProxy(vmPool.agentPoolName), nil))
-
 	return nodeInfo, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_vmss_delete_client.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vmss_delete_client.go
@@ -28,11 +28,13 @@ import (
 )
 
 // VMSSDeleteClient is an interface for async VMSS operations.
-// This interface wraps the azclient's VMSS client to access BeginDeleteInstances and BeginCreateOrUpdate
-// via the embedded SDK client for async polling.
+// This interface wraps the azclient's VMSS client to access BeginDeleteInstances, BeginCreateOrUpdate,
+// BeginStart, and BeginDeallocate via the embedded SDK client for async polling.
 type VMSSDeleteClient interface {
 	BeginDeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, options *armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse], error)
 	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters armcompute.VirtualMachineScaleSet, options *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error)
+	BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *armcompute.VirtualMachineScaleSetsClientBeginStartOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientStartResponse], error)
+	BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *armcompute.VirtualMachineScaleSetsClientBeginDeallocateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeallocateResponse], error)
 }
 
 // vmssDeleteClientWrapper wraps the azclient's VMSS client.
@@ -61,4 +63,14 @@ func (w *vmssDeleteClientWrapper) BeginDeleteInstances(ctx context.Context, reso
 // BeginCreateOrUpdate implements the VMSSDeleteClient interface.
 func (w *vmssDeleteClientWrapper) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters armcompute.VirtualMachineScaleSet, options *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
 	return w.client.VirtualMachineScaleSetsClient.BeginCreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, parameters, options)
+}
+
+// BeginStart implements the VMSSDeleteClient interface.
+func (w *vmssDeleteClientWrapper) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *armcompute.VirtualMachineScaleSetsClientBeginStartOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientStartResponse], error) {
+	return w.client.VirtualMachineScaleSetsClient.BeginStart(ctx, resourceGroupName, vmScaleSetName, options)
+}
+
+// BeginDeallocate implements the VMSSDeleteClient interface.
+func (w *vmssDeleteClientWrapper) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *armcompute.VirtualMachineScaleSetsClientBeginDeallocateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeallocateResponse], error) {
+	return w.client.VirtualMachineScaleSetsClient.BeginDeallocate(ctx, resourceGroupName, vmScaleSetName, options)
 }

--- a/cluster-autoscaler/cloudprovider/azure/deallocate/cloud_provider_deallocate.go
+++ b/cluster-autoscaler/cloudprovider/azure/deallocate/cloud_provider_deallocate.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deallocate
+
+// PolicyNodeGroup is a wrapper for a nodegroup that can have scaling policies
+type PolicyNodeGroup interface {
+	// ScaleDownPolicy returns whether this nodegroup instances will be deleted or deallocated on scale down
+	ScaleDownPolicy() ScaleDownPolicy
+}
+
+// ScaleDownPolicy is a string representation of the ScaleDownPolicy
+type ScaleDownPolicy string
+
+const (
+	// Delete means that on scale down, nodes will be deleted
+	Delete ScaleDownPolicy = "Delete"
+	// Deallocate means that on scale down, nodes will be deallocated and on scale-up they will
+	// be attempted to be started first
+	Deallocate ScaleDownPolicy = "Deallocate"
+)

--- a/cluster-autoscaler/cloudprovider/azure/examples/dev/aks-dev-deploy.sh
+++ b/cluster-autoscaler/cloudprovider/azure/examples/dev/aks-dev-deploy.sh
@@ -25,8 +25,13 @@ set -euo pipefail
 
 # assumed logged in (az login) and subscription set (az account set --subscription ...)
 
-# set resource group and ACR name (preferably unique)
-RG=${CODESPACE_NAME:-cluster-autoscaler-test}
+# Require AZURE_RESOURCE_GROUP or derive from CODESPACE_NAME (devcontainer).
+: "${AZURE_RESOURCE_GROUP:=${CODESPACE_NAME:-}}"
+if [[ -z "${AZURE_RESOURCE_GROUP}" ]]; then
+    echo "ERROR: AZURE_RESOURCE_GROUP must be set (or run inside a Codespace/devcontainer where CODESPACE_NAME is set)." >&2
+    exit 1
+fi
+RG="${AZURE_RESOURCE_GROUP}"
 ACR_NAME=$(echo "$RG" | tr -d -) # remove hyphens
 az group create --name "${RG}" --location westus3 --output none
 
@@ -68,6 +73,27 @@ export TENANT_ID_B64 RESOURCE_GROUP_MC_B64 VMSS_NAME CAS_UAI_CLIENTID SUBSCRIPTI
 yq '(.. | select(tag == "!!str")) |= envsubst(nu)' \
     cluster-autoscaler-vmss-wi-dynamic.yaml.tpl > \
     cluster-autoscaler-vmss-wi-dynamic.yaml
+
+# create the dynamic node group config (required by the AKS fork)
+kubectl apply -f - <<SETTINGS
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: autoscaler-settings
+  namespace: kube-system
+data:
+  settings.json: |
+    {
+      "nodeGroups": [
+        {
+          "name": "${VMSS_NAME}",
+          "minSize": 1,
+          "maxSize": 10,
+          "scaleDownPolicy": "Delete"
+        }
+      ]
+    }
+SETTINGS
 
 # skaffold dev/run/debug
 

--- a/cluster-autoscaler/cloudprovider/azure/examples/dev/cluster-autoscaler-vmss-wi-dynamic.yaml.tpl
+++ b/cluster-autoscaler/cloudprovider/azure/examples/dev/cluster-autoscaler-vmss-wi-dynamic.yaml.tpl
@@ -158,6 +158,11 @@ spec:
             - --logtostderr=true
             - --cloud-provider=azure
             - --skip-nodes-with-local-storage=false
+            - --skip-nodes-with-system-pods=false
+            - --scale-down-delay-after-add=10s
+            - --scale-down-unneeded-time=10s
+            - --scale-down-candidates-pool-ratio=1.0
+            - --unremovable-node-recheck-timeout=10s
             - --nodes=1:10:${VMSS_NAME}
           env:
             - name: ARM_SUBSCRIPTION_ID
@@ -193,6 +198,9 @@ spec:
             - mountPath: /etc/ssl/certs/ca-certificates.crt
               name: ssl-certs
               readOnly: true
+            - mountPath: /opt/conf/autoscaler
+              name: autoscaler-settings
+              readOnly: true
       # use system nodepool only
       affinity:
         nodeAffinity:
@@ -208,3 +216,6 @@ spec:
             path: /etc/ssl/certs/ca-certificates.crt
             type: ""
           name: ssl-certs
+        - configMap:
+            name: autoscaler-settings
+          name: autoscaler-settings

--- a/cluster-autoscaler/cloudprovider/azure/test/Makefile
+++ b/cluster-autoscaler/cloudprovider/azure/test/Makefile
@@ -64,12 +64,14 @@ help: ## Display help
 
 .PHONY: setup-cluster
 setup-cluster: ## Create AKS cluster + ACR + workload identity for e2e testing
+	@echo "-- creating cluster --"
 	cd $(DEV_DIR) && bash ./aks-dev-deploy.sh
 
 ##@ Build & Deploy
 
 .PHONY: deploy-local
 deploy-local: ## Build CAS and deploy to cluster via skaffold
+	@echo "-- deploying CAS to cluster --"
 	cd $(CAS_ROOT) && skaffold run --filename cloudprovider/azure/examples/dev/skaffold.yaml
 
 .PHONY: deploy-local-dev
@@ -80,6 +82,7 @@ deploy-local-dev: ## Build + deploy CAS in watch mode (auto-redeploy on changes)
 
 .PHONY: e2etests
 e2etests: ## Run e2e tests (CAS must already be deployed)
+	@echo "-- running e2e tests --"
 	go run github.com/onsi/ginkgo/v2/ginkgo \
 		--tags e2e \
 		-v --trace \

--- a/cluster-autoscaler/cloudprovider/azure/test/pkg/environment/environment.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/pkg/environment/environment.go
@@ -74,11 +74,23 @@ type Environment struct {
 
 // NewEnvironment creates a fully initialized Environment.
 func NewEnvironment(resourceGroup string, helm *HelmConfig) *Environment {
+	Expect(resourceGroup).NotTo(BeEmpty(), "resource-group flag is required")
+
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	Expect(subscriptionID).NotTo(BeEmpty(), "AZURE_SUBSCRIPTION_ID environment variable is required")
+
+	tenantID := os.Getenv("AZURE_TENANT_ID")
+	if helm.IsEnabled() {
+		Expect(tenantID).NotTo(BeEmpty(), "AZURE_TENANT_ID is required when Helm deployment is enabled")
+		Expect(helm.ClusterName).NotTo(BeEmpty(), "cluster-name flag is required when Helm deployment is enabled")
+		Expect(helm.ClientID).NotTo(BeEmpty(), "client-id flag is required when Helm deployment is enabled")
+	}
+
 	env := &Environment{
 		Ctx:            context.Background(),
 		ResourceGroup:  resourceGroup,
-		SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
-		TenantID:       os.Getenv("AZURE_TENANT_ID"),
+		SubscriptionID: subscriptionID,
+		TenantID:       tenantID,
 		Helm:           helm,
 	}
 
@@ -192,17 +204,17 @@ func (env *Environment) AllVMSSStable(g Gomega) {
 
 	nodes := &corev1.NodeList{}
 	g.Expect(env.K8s.List(env.Ctx, nodes)).To(Succeed())
-	g.Expect(nodes.Items).To(SatisfyAll(
-		HaveLen(expectedNodes),
-		ContainElements(Satisfy(func(node corev1.Node) bool {
-			for _, cond := range node.Status.Conditions {
-				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-					return true
-				}
+	g.Expect(nodes.Items).To(HaveLen(expectedNodes))
+	for _, node := range nodes.Items {
+		ready := false
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				ready = true
+				break
 			}
-			return false
-		})),
-	))
+		}
+		g.Expect(ready).To(BeTrue(), "node %s is not Ready", node.Name)
+	}
 }
 
 // --- K8s helpers ---

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -290,7 +290,32 @@ const (
 	InstanceCreating InstanceState = 2
 	// InstanceDeleting means instance is being deleted
 	InstanceDeleting InstanceState = 3
+	// InstanceFailed means instance has a failed provisioning state
+	InstanceFailed InstanceState = 4
+	// InstanceDeallocated means that the instance is deallocated
+	InstanceDeallocated InstanceState = 5
+	// InstanceDeallocating means the instance is currently being deallocated
+	InstanceDeallocating InstanceState = 6
 )
+
+func (s InstanceState) String() string {
+	switch s {
+	case InstanceRunning:
+		return "Running"
+	case InstanceCreating:
+		return "Creating"
+	case InstanceFailed:
+		return "Failed"
+	case InstanceDeleting:
+		return "Deleting"
+	case InstanceDeallocated:
+		return "Deallocated"
+	case InstanceDeallocating:
+		return "Deallocating"
+	default:
+		return fmt.Sprintf("%d", s)
+	}
+}
 
 // InstanceErrorInfo provides information about error condition on instance
 type InstanceErrorInfo struct {

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -315,22 +315,25 @@ func (tcp *TestCloudProvider) InsertNodeGroup(nodeGroup cloudprovider.NodeGroup)
 }
 
 // AddNodeGroup adds node group to test cloud provider.
-func (tcp *TestCloudProvider) AddNodeGroup(id string, min int, max int, size int) {
+func (tcp *TestCloudProvider) AddNodeGroup(id string, min int, max int, size int) cloudprovider.NodeGroup {
 	nodeGroup := tcp.BuildNodeGroup(id, min, max, size, true, false, "", nil)
 	tcp.InsertNodeGroup(nodeGroup)
+	return nodeGroup
 }
 
 // AddUpcomingNodeGroup adds upcoming node group to test cloud provider.
-func (tcp *TestCloudProvider) AddUpcomingNodeGroup(id string, min int, max int, size int) {
+func (tcp *TestCloudProvider) AddUpcomingNodeGroup(id string, min int, max int, size int) cloudprovider.NodeGroup {
 	nodeGroup := tcp.BuildNodeGroup(id, min, max, size, false, false, "", nil)
 	tcp.InsertNodeGroup(nodeGroup)
+	return nodeGroup
 }
 
 // AddNodeGroupWithCustomOptions adds node group with custom options
 // to test cloud provider.
-func (tcp *TestCloudProvider) AddNodeGroupWithCustomOptions(id string, min int, max int, size int, opts *config.NodeGroupAutoscalingOptions) {
+func (tcp *TestCloudProvider) AddNodeGroupWithCustomOptions(id string, min int, max int, size int, opts *config.NodeGroupAutoscalingOptions) cloudprovider.NodeGroup {
 	nodeGroup := tcp.BuildNodeGroup(id, min, max, size, true, false, "", opts)
 	tcp.InsertNodeGroup(nodeGroup)
+	return nodeGroup
 }
 
 // AddAutoprovisionedNodeGroup adds node group to test cloud provider.

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/api"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/scaleupfailures"
@@ -496,6 +498,16 @@ func (csr *ClusterStateRegistry) IsClusterHealthy() bool {
 
 	totalUnready := len(csr.totalReadiness.Unready)
 
+	// Deallocate mode specific check
+	// Do not consider deallocated nodes in the cluster health check
+	// Those nodes will always exist in NotReady state
+	totalUnready = csr.calcDeallocationNodes(totalUnready, csr.totalReadiness.Unready)
+	// This shouldn't happen but if it doesn assume healthy
+	if totalUnready < 0 {
+		klog.Warningf("Delta is negative - assuming cluster is healthy")
+		return true
+	}
+
 	if totalUnready > csr.config.OkTotalUnreadyCount &&
 		float64(totalUnready) > csr.config.MaxTotalUnreadyPercentage/100.0*float64(len(csr.nodes)) {
 		return false
@@ -563,7 +575,7 @@ func (csr *ClusterStateRegistry) BackoffStatusForNodeGroup(nodeGroup cloudprovid
 
 // NodeGroupScaleUpSafety returns information about node group safety to be scaled up now.
 func (csr *ClusterStateRegistry) NodeGroupScaleUpSafety(nodeGroup cloudprovider.NodeGroup, now time.Time) NodeGroupScalingSafety {
-	isHealthy := csr.IsNodeGroupHealthy(nodeGroup.Id())
+	isHealthy := csr.IsNodeGroupHealthy(nodeGroup.Id()) || csr.IsNodeGroupHealthyDeallocate(nodeGroup)
 	var backoffStatus backoff.Status
 	nodeGroupInfo, found := csr.templateNodeInfoRegistry.GetNodeInfo(nodeGroup.Id())
 	if !found {
@@ -700,6 +712,8 @@ type Readiness struct {
 	LongUnregistered []string
 	// Names of nodes that haven't yet registered.
 	Unregistered []string
+	// Number of deallocated nodes that exist in K8s
+	Deallocated []string
 	// Time when the readiness was measured.
 	Time time.Time
 	// Names of nodes that are Unready due to missing resources.
@@ -721,7 +735,9 @@ func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
 	perNodeGroup := make(map[string]Readiness)
 	total := Readiness{Time: currentTime}
 	maxNodeStartupTime := MaxNodeStartupTime
-	update := func(current Readiness, node *apiv1.Node, nr kube_util.NodeReadiness) Readiness {
+	update := func(current Readiness, node *apiv1.Node, nr kube_util.NodeReadiness, nodeGroup cloudprovider.NodeGroup) Readiness {
+		// TODO: (deallocate) Could not isolate deallocate mode logic effectively for this function.
+		policyNg, ok := nodeGroup.(deallocate.PolicyNodeGroup)
 		nodeGroup, errNg := csr.cloudProvider.NodeGroupForNode(node)
 		if errNg == nil && nodeGroup != nil {
 			if startupTime, err := csr.nodeGroupConfigProcessor.GetMaxNodeStartupTime(nodeGroup); err == nil {
@@ -732,6 +748,11 @@ func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
 		current.Registered = append(current.Registered, node.Name)
 		if _, isDeleted := csr.deletedNodes[node.Name]; isDeleted {
 			current.Deleted = append(current.Deleted, node.Name)
+			// Also use unreachable to account for delays in applying shutdown taint
+		} else if (nodeGroup != nil && ok && policyNg.ScaleDownPolicy() == deallocate.Deallocate) && (taints.HasShutdownTaint(node) || taints.HasUnreachableTaint(node)) {
+			// TODO: When removing Deallocate mode, remove this if-nest.
+			current.Deallocated = append(current.Deallocated, node.Name)
+			current.Unready = append(current.Unready, node.Name)
 		} else if isSuspendedNode(node) {
 			current.Suspended = append(current.Suspended, node.Name)
 		} else if nr.Ready {
@@ -760,9 +781,9 @@ func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
 				klog.Warningf("Failed to get readiness info for %s: %v", node.Name, errReady)
 			}
 		} else {
-			perNodeGroup[nodeGroup.Id()] = update(perNodeGroup[nodeGroup.Id()], node, nr)
+			perNodeGroup[nodeGroup.Id()] = update(perNodeGroup[nodeGroup.Id()], node, nr, nodeGroup)
 		}
-		total = update(total, node, nr)
+		total = update(total, node, nr, nodeGroup)
 	}
 
 	for _, unregistered := range csr.unregisteredNodes {
@@ -911,7 +932,7 @@ func (csr *ClusterStateRegistry) GetStatus(now time.Time) *api.ClusterAutoscaler
 
 		// Health.
 		nodeGroupStatus.Health = buildHealthStatusNodeGroup(
-			csr.IsNodeGroupHealthy(nodeGroup.Id()), readiness, acceptable, nodeGroup.MinSize(), nodeGroup.MaxSize(), nodeGroupLastStatus.Health)
+			csr.IsNodeGroupHealthy(nodeGroup.Id()) || csr.IsNodeGroupHealthyDeallocate(nodeGroup), readiness, acceptable, nodeGroup.MinSize(), nodeGroup.MaxSize(), nodeGroupLastStatus.Health)
 
 		// Scale up.
 		nodeGroupStatus.ScaleUp = csr.buildScaleUpStatusNodeGroup(
@@ -1109,6 +1130,9 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() (upcomingCounts map[string]i
 	registeredNodeNames = map[string][]string{}
 	for _, nodeGroup := range csr.cloudProvider.NodeGroups() {
 		id := nodeGroup.Id()
+		// Looks like this always return false as of 09042024. Unfinished feature? Seems like it is intended to be controlled by `AsyncNodeGroupsEnabled` flag.
+		// It probably need some effort to check the compatibility with deallocate mode. Until then, let's make sure it wouldn't become active with deallocate mode.
+		// https://github.com/kubernetes/autoscaler/pull/7103
 		if csr.asyncNodeGroupStateChecker.IsUpcoming(nodeGroup) {
 			size, err := nodeGroup.TargetSize()
 			if size >= 0 || err != nil {
@@ -1116,10 +1140,22 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() (upcomingCounts map[string]i
 			}
 			continue
 		}
+		policyNg, ok := nodeGroup.(deallocate.PolicyNodeGroup)
+
 		readiness := csr.perNodeGroupReadiness[id]
 		ar := csr.acceptableRanges[id]
 		// TODO: Unify the logic determining the input to calculateUpcomingNodesInNodeGroup() with getUpcomingNodesInNodeGroup().
 		newNodes := calculateUpcomingNodesInNodeGroup(readiness, ar)
+
+		// Deallocate-specific calculation
+		if ok && policyNg.ScaleDownPolicy() == deallocate.Deallocate {
+			// newNodes are the upcoming nodes. This is the TargetSize (goal state of the nodegroup) subtracted from (the current ready nodes + (nodes transitioning from deallocated state to running))+ unregistered + still starting nodes)
+			newNodes = ar.CurrentTarget - (len(readiness.Ready) + (len(readiness.Unready) - len(readiness.Deallocated)) + len(readiness.LongUnregistered))
+		}
+
+		klog.V(3).Infof("newNodes: %d, currentTarget: %d, deallocated: %d, readinessReady: %d, readinessUnready: %d, readiness.LongUnregistered: %d for nodeGroup %s", newNodes,
+			ar.CurrentTarget, len(readiness.Deallocated), len(readiness.Ready), len(readiness.Unready), len(readiness.LongUnregistered), id)
+
 		if newNodes <= 0 {
 			// Negative value is unlikely but theoretically possible.
 			continue

--- a/cluster-autoscaler/clusterstate/clusterstate_deallocate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_deallocate_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterstate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	mockprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/mocks"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	"k8s.io/client-go/kubernetes/fake"
+	kube_record "k8s.io/client-go/tools/record"
+)
+
+// TestHandleInstanceCreationErrorsStartDeallocatedFailed verifies that deallocated VMs
+// that fail to start trigger backoff with the expected Azure-specific error code.
+func TestHandleInstanceCreationErrorsStartDeallocatedFailed(t *testing.T) {
+	now := time.Now()
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	mockedNodeGroup := &mockprovider.NodeGroup{}
+	mockedNodeGroup.On("Id").Return("deallocate-pool")
+	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{
+		{
+			Id: "vm1",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "start-deallocated-failed",
+					ErrorMessage: "Failed to start deallocated VM",
+				},
+			},
+		},
+		{
+			Id: "vm2",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "start-deallocated-failed",
+					ErrorMessage: "Failed to start deallocated VM",
+				},
+			},
+		},
+	}, nil)
+	mockedNodeGroup.On("Autoprovisioned").Return(false)
+	mockedNodeGroup.On("TargetSize").Return(2, nil)
+	node := BuildTestNode("deallocate-pool_1", 1000, 1000)
+	mockedNodeGroup.On("TemplateNodeInfo").Return(framework.NewTestNodeInfo(node), nil)
+	mockedNodeGroup.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
+	provider.InsertNodeGroup(mockedNodeGroup)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	mockMetrics := &mockMetrics{}
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+	clusterstate.RegisterScaleUp(mockedNodeGroup, 2, now)
+
+	// UpdateNodes will trigger handleInstanceCreationErrors.
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
+
+	// Verify metrics were recorded.
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("start-deallocated-failed"), "", "")
+
+	// Verify the node group is in backoff with the correct error code.
+	safety := clusterstate.NodeGroupScaleUpSafety(mockedNodeGroup, now)
+	assert.False(t, safety.SafeToScale, "node group should not be safe to scale")
+	assert.True(t, safety.BackoffStatus.IsBackedOff, "node group should be backed off after start-deallocated-failed")
+	assert.Equal(t, "start-deallocated-failed", safety.BackoffStatus.ErrorInfo.ErrorCode)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, safety.BackoffStatus.ErrorInfo.ErrorClass)
+}

--- a/cluster-autoscaler/clusterstate/clusterstate_deallocate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_deallocate_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/client-go/kubernetes/fake"
@@ -79,16 +78,22 @@ func TestHandleInstanceCreationErrorsStartDeallocatedFailed(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
-	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
-	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	nodeInfos := map[string]*framework.NodeInfo{
+		"deallocate-pool": framework.NewTestNodeInfo(node),
+	}
+	registry := newMockTemplateNodeInfoRegistry(nodeInfos)
+	clusterstate := NewNotifiedClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), registry, withMetrics(mockMetrics, provider))
 	clusterstate.RegisterScaleUp(mockedNodeGroup, 2, now)
 
 	// UpdateNodes will trigger handleInstanceCreationErrors.
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, now)
 	assert.NoError(t, err)
 
 	// Verify metrics were recorded.
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("start-deallocated-failed"), "", "")
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("start-deallocated-failed"), "", "", "")
+	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("start-deallocated-failed"), 2)
 
 	// Verify the node group is in backoff with the correct error code.
 	safety := clusterstate.NodeGroupScaleUpSafety(mockedNodeGroup, now)

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -1754,7 +1754,11 @@ func TestHandleInstanceCreationErrors(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
-	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider))
+	nodeInfos := map[string]*framework.NodeInfo{
+		"ng1": framework.NewTestNodeInfo(node),
+	}
+	registry := newMockTemplateNodeInfoRegistry(nodeInfos)
+	clusterstate := NewNotifiedClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}), registry, withMetrics(mockMetrics, provider))
 	clusterstate.RegisterScaleUp(mockedNodeGroup, 1, now)
 
 	// UpdateNodes will trigger handleInstanceCreationErrors

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -1762,6 +1762,13 @@ func TestHandleInstanceCreationErrors(t *testing.T) {
 	assert.NoError(t, err)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 2)
+
+	// Verify the node group is in backoff with the correct error code
+	safety := clusterstate.NodeGroupScaleUpSafety(mockedNodeGroup, now)
+	assert.False(t, safety.SafeToScale, "node group should not be safe to scale")
+	assert.True(t, safety.BackoffStatus.IsBackedOff, "node group should be backed off")
+	assert.Equal(t, "RESOURCE_POOL_EXHAUSTED", safety.BackoffStatus.ErrorInfo.ErrorCode)
+	assert.Equal(t, cloudprovider.OutOfResourcesErrorClass, safety.BackoffStatus.ErrorInfo.ErrorClass)
 }
 
 func TestFailedScaleUpWithDra(t *testing.T) {

--- a/cluster-autoscaler/clusterstate/deallocate.go
+++ b/cluster-autoscaler/clusterstate/deallocate.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterstate
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+	klog "k8s.io/klog/v2"
+)
+
+func (csr *ClusterStateRegistry) calcDeallocationNodes(delta int, totalUnready []string) int {
+	if isAnyNodeGroupInDeallocationMode(csr.cloudProvider.NodeGroups()) {
+		totalDeallocated := csr.totalReadiness.Deallocated
+		delta = len(totalUnready) - len(totalDeallocated)
+		klog.V(5).Infof("Cluster Health Check - totalUnready: %d, totalDeallocated: %d", len(totalUnready), len(totalDeallocated))
+	}
+	return delta
+}
+
+// IsNodeGroupHealthyDeallocate returns true if the node group is in deallocate mode.
+func (csr *ClusterStateRegistry) IsNodeGroupHealthyDeallocate(nodeGroup cloudprovider.NodeGroup) bool {
+	// NodeGroups with deallocated nodes can have a lot of Unready nodes - disable the health check
+	// for those so they can be scaled up
+	policyNg, ok := nodeGroup.(deallocate.PolicyNodeGroup)
+	if ok && policyNg.ScaleDownPolicy() == deallocate.Deallocate {
+		return true
+	}
+	return false
+}
+
+// isAnyNodeGroupInDeallocationMode returns true iff any nodegroup in the list is of Deallocate policy
+func isAnyNodeGroupInDeallocationMode(ngs []cloudprovider.NodeGroup) bool {
+	for _, ng := range ngs {
+		policyNg, ok := ng.(deallocate.PolicyNodeGroup)
+		if !ok {
+			return false
+		}
+		if policyNg.ScaleDownPolicy() == deallocate.Deallocate {
+			return true
+		}
+	}
+	return false
+}

--- a/cluster-autoscaler/config/dynamic/config.go
+++ b/cluster-autoscaler/config/dynamic/config.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+	"k8s.io/klog/v2"
+)
+
+// Config holds the dynamic configuration of autoscaler which can be refreshed at runtime
+type Config struct {
+	NodeGroups []NodeGroupSpec `json:"nodeGroups" yaml:"nodeGroups"`
+}
+
+// NewDefaultConfig returns a default empty config
+func NewDefaultConfig() Config {
+	return Config{
+		NodeGroups: []NodeGroupSpec{},
+	}
+}
+
+// BuildConfig builds a Config object from the mounted path
+func BuildConfig(reader io.Reader) (*Config, error) {
+	config, err := umarshalConfig(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode autoscaler config: %v", err)
+	}
+
+	klog.V(4).Infof("nodeGroups=%v", config.NodeGroups)
+
+	var modifiedNg []NodeGroupSpec
+	for _, spec := range config.NodeGroups {
+		localSpec := spec
+		if spec.ScaleDownPolicy == "" {
+			localSpec.ScaleDownPolicy = deallocate.Delete
+		}
+		modifiedNg = append(modifiedNg, localSpec)
+	}
+	config.NodeGroups = modifiedNg
+	if err := config.validate(); err != nil {
+		return nil, fmt.Errorf("error while validating config: %v", err)
+	}
+
+	return &config, nil
+}
+
+// umarshalConfig decodes the yaml or json reader into a struct
+func umarshalConfig(reader io.Reader) (Config, error) {
+	config := Config{}
+	if err := yaml.NewYAMLOrJSONDecoder(reader, 4096).Decode(&config); err != nil {
+		return Config{}, err
+	}
+	return config, nil
+}
+
+// NodeGroupSpecStrings returns node group specs represented in the form of `<minSize>:<maxSize>:<name>:<labels>|<taints>` to be passed to
+// the cloudprovider autoscaling options
+func (c Config) NodeGroupSpecStrings() []string {
+	result := []string{}
+	for _, spec := range c.NodeGroups {
+		result = append(result, spec.StringWithLabelsAndTaints())
+	}
+	return result
+}
+
+func (c Config) validate() error {
+	for _, g := range c.NodeGroups {
+		if g.Name == "" {
+			return fmt.Errorf("invalid nodeGroup: name must not be blank")
+		}
+		if g.MaxSize < g.MinSize {
+			return fmt.Errorf("invalid nodeGroup: %s, max size must be greater or equal to min size", g.Name)
+		}
+		if g.ScaleDownPolicy != deallocate.Delete && g.ScaleDownPolicy != deallocate.Deallocate {
+			return fmt.Errorf("invalid scaledown policy: %s. Valid values are: Delete, Deallocate", g.ScaleDownPolicy)
+		}
+	}
+	return nil
+}

--- a/cluster-autoscaler/config/dynamic/config_fetcher.go
+++ b/cluster-autoscaler/config/dynamic/config_fetcher.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	"k8s.io/klog/v2"
+)
+
+// ConfigFetcher fetches the up-to-date dynamic configuration from the mounted configmap
+type ConfigFetcher interface {
+	FetchConfigIfUpdated() (*Config, error)
+}
+
+type configFetcher struct {
+	path                  string
+	previousConfiguration Config
+}
+
+// ConfigFetcherOptions contains options to customize the ConfigFetcher
+type ConfigFetcherOptions struct {
+	ConfigPath string
+}
+
+// NewConfigFetcher builds a config fetcher
+func NewConfigFetcher(options ConfigFetcherOptions) *configFetcher {
+	return &configFetcher{
+		path:                  options.ConfigPath,
+		previousConfiguration: NewDefaultConfig(),
+	}
+}
+
+// Returns the config if it has changed and nil if it hasn't
+func (cf *configFetcher) FetchConfigIfUpdated() (*Config, error) {
+	configFile, err := os.Open(cf.path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config file: %v", err)
+	}
+
+	config, err := BuildConfig(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load dynamic config: %v", err)
+	}
+
+	if err := configFile.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close config file: %v", err)
+	}
+
+	if reflect.DeepEqual(cf.previousConfiguration, *config) {
+		klog.V(4).Infof("config matches previous one - no need to update")
+		return nil, nil
+	}
+
+	// else config has changed, update
+	cf.previousConfiguration = *config
+	return config, nil
+}
+
+// Returns the config regardless of whether it has changed, also updates the previous configuration
+func (cf *configFetcher) ForceFetchConfig() (*Config, error) {
+	configFile, err := os.Open(cf.path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config file: %v", err)
+	}
+
+	config, err := BuildConfig(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load dynamic config: %v", err)
+	}
+
+	if err := configFile.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close config file: %v", err)
+	}
+
+	cf.previousConfiguration = *config
+	return config, nil
+}

--- a/cluster-autoscaler/config/dynamic/config_test.go
+++ b/cluster-autoscaler/config/dynamic/config_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var configNodeGroupsInvalid = `
+    {
+      "nodeGroups": "name"
+    }
+`
+
+var configValid = `
+{
+	"nodeGroups": [
+	  {
+		"minSize": 1,
+		"maxSize": 100,
+		"name": "aks-nodepool1-24160808-vmss",
+        "scaleDownPolicy": "Delete"
+	  }
+	]
+  }
+`
+
+func TestBuildConfig(t *testing.T) {
+	t.Run("test BuildConfig invalid", func(t *testing.T) {
+		yamlReader := strings.NewReader(configNodeGroupsInvalid)
+		config, err := BuildConfig(yamlReader)
+		assert.Error(t, err)
+		assert.Empty(t, config)
+	})
+
+	t.Run("test BuildConfig valid", func(t *testing.T) {
+		yamlReader := strings.NewReader(configValid)
+		config, err := BuildConfig(yamlReader)
+		assert.NoError(t, err)
+		assert.Equal(t, "aks-nodepool1-24160808-vmss", config.NodeGroups[0].Name)
+		assert.Equal(t, 1, config.NodeGroups[0].MinSize)
+		assert.Equal(t, 100, config.NodeGroups[0].MaxSize)
+		assert.Equal(t, deallocate.Delete, config.NodeGroups[0].ScaleDownPolicy)
+	})
+}
+
+func TestUnmarshalConfig(t *testing.T) {
+	t.Run("test UnmarshalConfig nodeGroups invalid", func(t *testing.T) {
+		yamlReader := strings.NewReader(configNodeGroupsInvalid)
+		config, err := umarshalConfig(yamlReader)
+		assert.Error(t, err)
+		assert.Empty(t, config)
+	})
+
+	t.Run("test UnmarshalConfig valid", func(t *testing.T) {
+		yamlReader := strings.NewReader(configValid)
+		config, err := umarshalConfig(yamlReader)
+		assert.NoError(t, err)
+		assert.Equal(t, "aks-nodepool1-24160808-vmss", config.NodeGroups[0].Name)
+		assert.Equal(t, 1, config.NodeGroups[0].MinSize)
+		assert.Equal(t, 100, config.NodeGroups[0].MaxSize)
+		assert.Equal(t, deallocate.Delete, config.NodeGroups[0].ScaleDownPolicy)
+
+	})
+}
+func TestValidate(t *testing.T) {
+	t.Run("test validate valid", func(t *testing.T) {
+		c := &Config{
+			NodeGroups: []NodeGroupSpec{
+				{
+					Name:            "test1",
+					MinSize:         1,
+					MaxSize:         50,
+					ScaleDownPolicy: deallocate.Delete,
+				},
+				{
+					Name:            "test2",
+					MinSize:         10,
+					MaxSize:         70,
+					ScaleDownPolicy: deallocate.Deallocate,
+				},
+			},
+		}
+		err := c.validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("test validate empty name", func(t *testing.T) {
+		c := &Config{
+			NodeGroups: []NodeGroupSpec{
+				{
+					Name:    "",
+					MinSize: 1,
+					MaxSize: 50,
+				},
+				{
+					Name:    "test2",
+					MinSize: 10,
+					MaxSize: 70,
+				},
+			},
+		}
+		err := c.validate()
+		assert.EqualError(t, err, "invalid nodeGroup: name must not be blank")
+	})
+
+	t.Run("test validate wrong min/max", func(t *testing.T) {
+		c := &Config{
+			NodeGroups: []NodeGroupSpec{
+				{
+					Name:    "test1",
+					MinSize: 100,
+					MaxSize: 50,
+				},
+				{
+					Name:    "test2",
+					MinSize: 10,
+					MaxSize: 70,
+				},
+			},
+		}
+		err := c.validate()
+		assert.EqualError(t, err, "invalid nodeGroup: test1, max size must be greater or equal to min size")
+	})
+
+	t.Run("test validate invalid scaleDownPolicy", func(t *testing.T) {
+		c := &Config{
+			NodeGroups: []NodeGroupSpec{
+				{
+					Name:            "test1",
+					MinSize:         1,
+					MaxSize:         50,
+					ScaleDownPolicy: "InvalidPolicy",
+				},
+				{
+					Name:    "test2",
+					MinSize: 10,
+					MaxSize: 70,
+				},
+			},
+		}
+		err := c.validate()
+		assert.EqualError(t, err, "invalid scaledown policy: InvalidPolicy. Valid values are: Delete, Deallocate")
+	})
+}
+
+func TestNodeGroupSpecStrings(t *testing.T) {
+	t.Run("no labels or taints", func(t *testing.T) {
+		c := &Config{
+			NodeGroups: []NodeGroupSpec{
+				{
+					Name:            "test1",
+					MinSize:         1,
+					MaxSize:         50,
+					ScaleDownPolicy: deallocate.Delete,
+				},
+				{
+					Name:            "test2",
+					MinSize:         10,
+					MaxSize:         70,
+					ScaleDownPolicy: deallocate.Deallocate,
+				},
+			},
+		}
+		specStrings := c.NodeGroupSpecStrings()
+		assert.Equal(t, []string{"1:50:Delete:test1:{}|", "10:70:Deallocate:test2:{}|"}, specStrings)
+	})
+
+	t.Run("only labels no taints", func(t *testing.T) {
+		c := &Config{
+			NodeGroups: []NodeGroupSpec{
+				{
+					Name:            "test1",
+					MinSize:         1,
+					MaxSize:         50,
+					ScaleDownPolicy: deallocate.Deallocate,
+				},
+				{
+					Name:            "test2",
+					MinSize:         10,
+					MaxSize:         70,
+					ScaleDownPolicy: deallocate.Deallocate,
+					Labels: map[string]string{
+						"environment": "prod",
+					},
+				},
+			},
+		}
+		specStrings := c.NodeGroupSpecStrings()
+		assert.Equal(t, []string{"1:50:Deallocate:test1:{}|", "10:70:Deallocate:test2:{\"environment\":\"prod\"}|"}, specStrings)
+	})
+
+	t.Run("only taints", func(t *testing.T) {
+		c := &Config{
+			NodeGroups: []NodeGroupSpec{
+				{
+					Name:            "test1",
+					MinSize:         1,
+					MaxSize:         50,
+					Taints:          "key1=value1:NoSchedule,key2=value2:NoSchedule",
+					ScaleDownPolicy: deallocate.Delete,
+				},
+				{
+					Name:            "test2",
+					MinSize:         10,
+					MaxSize:         70,
+					ScaleDownPolicy: deallocate.Delete,
+				},
+			},
+		}
+		specStrings := c.NodeGroupSpecStrings()
+		assert.Equal(t, []string{"1:50:Delete:test1:{}|key1=value1:NoSchedule,key2=value2:NoSchedule", "10:70:Delete:test2:{}|"}, specStrings)
+	})
+
+	t.Run("mix of labels and taints", func(t *testing.T) {
+		c := &Config{
+			NodeGroups: []NodeGroupSpec{
+				{
+					Name:    "test1",
+					MinSize: 1,
+					MaxSize: 50,
+					Taints:  "key1=value1:NoSchedule,key2=value2:NoSchedule",
+					Labels: map[string]string{
+						"environment": "prod",
+					},
+					ScaleDownPolicy: deallocate.Delete,
+				},
+				{
+					Name:    "test2",
+					MinSize: 10,
+					MaxSize: 70,
+					Labels: map[string]string{
+						"environment": "staging",
+					},
+					ScaleDownPolicy: deallocate.Delete,
+				},
+				{
+					Name:    "test3",
+					MinSize: 1,
+					MaxSize: 5,
+					Labels: map[string]string{
+						"environment": "dev",
+						"owner":       "myself",
+					},
+					Taints:          "key1=value1:NoSchedule,key2=value2:NoSchedule",
+					ScaleDownPolicy: deallocate.Delete,
+				},
+			},
+		}
+		specStrings := c.NodeGroupSpecStrings()
+		assert.Equal(t, []string{"1:50:Delete:test1:{\"environment\":\"prod\"}|key1=value1:NoSchedule,key2=value2:NoSchedule",
+			"10:70:Delete:test2:{\"environment\":\"staging\"}|",
+			"1:5:Delete:test3:{\"environment\":\"dev\",\"owner\":\"myself\"}|key1=value1:NoSchedule,key2=value2:NoSchedule"}, specStrings)
+	})
+}

--- a/cluster-autoscaler/config/dynamic/node_group_spec.go
+++ b/cluster-autoscaler/config/dynamic/node_group_spec.go
@@ -17,9 +17,13 @@ limitations under the License.
 package dynamic
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+	"k8s.io/klog/v2"
 )
 
 // NodeGroupSpec represents a specification of a node group to be auto-scaled
@@ -29,9 +33,88 @@ type NodeGroupSpec struct {
 	// Min size of the autoscaling target
 	MinSize int `json:"minSize"`
 	// Max size of the autoscaling target
-	MaxSize int `json:"maxSize"`
+	MaxSize         int                        `json:"maxSize"`
+	Taints          string                     `json:"taints"`
+	Labels          map[string]string          `json:"labels"`
+	ScaleDownPolicy deallocate.ScaleDownPolicy `json:"scaleDownPolicy"`
 	// Specifies whether this node group can scale to zero nodes.
 	SupportScaleToZero bool
+}
+
+// SpecFromStringWithLabelsAndTaints parses a node group spec represented in the form of `<minSize>:<maxSize>:<policy>:<name>:<labels>|<string>`
+// and produces a node group spec object
+// It falls-back to the the default
+func SpecFromStringWithLabelsAndTaints(value string, SupportScaleToZero bool) (*NodeGroupSpec, error) {
+	tokens := strings.SplitN(value, ":", 5)
+
+	if len(tokens) == 3 {
+		return SpecFromString(value, SupportScaleToZero)
+	}
+	if len(tokens) < 4 {
+		return nil, fmt.Errorf("error while parsing NodeGroupSpec: %s", value)
+	}
+
+	// first parse the min, max, name and deallocation mode
+	spec, err := SpecFromPolicyString(strings.Join(tokens[0:4], ":"), SupportScaleToZero)
+	if err != nil {
+		return nil, fmt.Errorf("error while parsing NodeGroupSpec: %s, %s", value, err)
+	}
+
+	if len(tokens) > 4 {
+		labelsTaints := strings.Split(tokens[4], "|")
+		// attempt to parse labels
+		var labels map[string]string
+		err = json.Unmarshal([]byte(labelsTaints[0]), &labels)
+		if err != nil {
+			return nil, fmt.Errorf("error while parsing NodeGroupSpec: %s for labels, %s", value, err)
+		}
+
+		spec.Labels = labels
+		if len(labelsTaints) > 1 {
+			spec.Taints = labelsTaints[1]
+		}
+	}
+	klog.V(4).Infof("Parsed spec is: nodeName: %s, minSize: %d, maxSize: %d,"+
+		"labels: %s, taints:%s, supportScaleToZero: %t", spec.Name, spec.MinSize, spec.MaxSize, spec.Labels, spec.Taints, spec.SupportScaleToZero)
+	return spec, err
+}
+
+// SpecFromPolicyString parses a node group spec represented in the form of `<minSize>:<maxSize>:<policy>:<name>` and produces a node group spec object
+func SpecFromPolicyString(value string, SupportScaleToZero bool) (*NodeGroupSpec, error) {
+	tokens := strings.SplitN(value, ":", 4)
+	if len(tokens) != 4 {
+		return nil, fmt.Errorf("wrong nodes configuration: %s", value)
+	}
+
+	spec := NodeGroupSpec{SupportScaleToZero: SupportScaleToZero}
+	if size, err := strconv.Atoi(tokens[0]); err == nil {
+		spec.MinSize = size
+	} else {
+		return nil, fmt.Errorf("failed to set min size: %s, expected integer", tokens[0])
+	}
+
+	if size, err := strconv.Atoi(tokens[1]); err == nil {
+		spec.MaxSize = size
+	} else {
+		return nil, fmt.Errorf("failed to set max size: %s, expected integer", tokens[1])
+	}
+
+	switch tokens[2] {
+	case string(deallocate.Delete):
+		spec.ScaleDownPolicy = deallocate.Delete
+	case string(deallocate.Deallocate):
+		spec.ScaleDownPolicy = deallocate.Deallocate
+	default:
+		return nil, fmt.Errorf("failed to set scale down policy: %s. Valid values are: Delete, Deallocate", tokens[2])
+	}
+
+	spec.Name = tokens[3]
+
+	if err := spec.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid node group spec: %v", err)
+	}
+
+	return &spec, nil
 }
 
 // SpecFromString parses a node group spec represented in the form of `<minSize>:<maxSize>:<name>` and produces a node group spec object
@@ -84,7 +167,16 @@ func (s NodeGroupSpec) Validate() error {
 	return nil
 }
 
-// Represents the node group spec in the form of `<minSize>:<maxSize>:<name>`
+// Represents the node group spec in the form of `<minSize>:<maxSize>:<scaleDownPolicy>:<name>`
 func (s NodeGroupSpec) String() string {
-	return fmt.Sprintf("%d:%d:%s", s.MinSize, s.MaxSize, s.Name)
+	return fmt.Sprintf("%d:%d:%s:%s", s.MinSize, s.MaxSize, s.ScaleDownPolicy, s.Name)
+}
+
+// StringWithLabelsAndTaints the node group spec in the form of `<minSize>:<maxSize>:<scaleDownPolicy>:<name>:<labels>|<taints>`
+func (s NodeGroupSpec) StringWithLabelsAndTaints() string {
+	if len(s.Labels) == 0 {
+		s.Labels = map[string]string{}
+	}
+	labels, _ := json.Marshal(s.Labels)
+	return fmt.Sprintf("%d:%d:%s:%s:%s|%s", s.MinSize, s.MaxSize, s.ScaleDownPolicy, s.Name, labels, s.Taints)
 }

--- a/cluster-autoscaler/config/dynamic/node_group_spec_test.go
+++ b/cluster-autoscaler/config/dynamic/node_group_spec_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+)
+
+func TestSpecFromString(t *testing.T) {
+	t.Run("invalid string - missing token", func(t *testing.T) {
+		specString := "1:50:aks-nodepool-83823-vmss"
+		spec, err := SpecFromStringWithLabelsAndTaints(specString, true)
+		assert.NoError(t, err)
+		assert.Equal(t, *spec, NodeGroupSpec{Name: "aks-nodepool-83823-vmss", MinSize: 1, MaxSize: 50, SupportScaleToZero: true})
+	})
+	t.Run("valid string", func(t *testing.T) {
+		specString := "1:50:Delete:aks-nodepool-83823-vmss"
+		spec, err := SpecFromStringWithLabelsAndTaints(specString, true)
+		assert.NoError(t, err)
+		assert.Equal(t, *spec, NodeGroupSpec{Name: "aks-nodepool-83823-vmss", MinSize: 1, MaxSize: 50, ScaleDownPolicy: deallocate.Delete, SupportScaleToZero: true})
+	})
+}
+
+func TestSpecFromStringWithLabelsAndTaints(t *testing.T) {
+	t.Run("invalid string - missing token", func(t *testing.T) {
+		specString := "1:50:aks-nodepool-83823-vmss:{}|"
+		spec, err := SpecFromStringWithLabelsAndTaints(specString, true)
+		assert.EqualError(t, err, "error while parsing NodeGroupSpec: 1:50:aks-nodepool-83823-vmss:{}|, failed to set scale down policy: aks-nodepool-83823-vmss. Valid values are: Delete, Deallocate")
+		assert.Nil(t, spec)
+	})
+	t.Run("valid string", func(t *testing.T) {
+		specString := "1:50:Delete:aks-nodepool-83823-vmss:{}|"
+		spec, err := SpecFromStringWithLabelsAndTaints(specString, true)
+		assert.NoError(t, err)
+		assert.Equal(t, *spec, NodeGroupSpec{Name: "aks-nodepool-83823-vmss", MinSize: 1, MaxSize: 50, ScaleDownPolicy: deallocate.Delete, SupportScaleToZero: true, Labels: map[string]string{}})
+	})
+}

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -28,6 +28,7 @@ import (
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce/localssdsize"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	scheduler_util "k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
@@ -252,13 +253,27 @@ var (
 	scaleDownEnabled           = flag.Bool("scale-down-enabled", true, "[Deprecated] Should CA scale down the cluster")
 )
 
+// fork-specific flags that are no longer functional but kept for compatibility.
+var (
+	configPath                = flag.String("config-path", "", "The path for the mounted ConfigMap containing the settings used for dynamic reconfiguration. Set as empty string to use static mode.")
+	enableForceDelete         = flag.Bool("enable-force-delete", false, "Whether to enable force deletion")
+	enableDynamicInstanceList = flag.Bool("enable-dynamic-instance-list", false, "Whether to enable dynamic instance list workflow")
+	enableDetailedCSEMessage  = flag.Bool("enable-detailed-cse-message", false, "Whether to enable emitting error messages in CSE error body")
+)
+
+var (
+	// ConfigFetcher is used to fetch dynamic configuration for the cluster autoscaler.
+	// Temporary + fork only, will be removed after CA is made restartable by PUT AP and have NodeGroups passed in by flags.
+	ConfigFetcher dynamic.ConfigFetcher
+)
+
 var autoscalingOptions *config.AutoscalingOptions
 
 // AutoscalingOptions returns the singleton instance of AutoscalingOptions, initializing it if necessary.
 func AutoscalingOptions() config.AutoscalingOptions {
-	if autoscalingOptions == nil {
-		newAutoscalingOptions := createAutoscalingOptions()
-		autoscalingOptions = &newAutoscalingOptions
+	if autoscalingOptions == nil { // Fork: assert: createAutoscalingOptions (first NodeGroups fetched) must be called only once per lifetime, until dynamic config is fully deforked
+		newAutoscalingOptions := createAutoscalingOptions() // Fork: assert: createAutoscalingOptions (first NodeGroups fetched) must be called only once per lifetime, until dynamic config is fully deforked
+		autoscalingOptions = &newAutoscalingOptions         // Fork: assert: createAutoscalingOptions (first NodeGroups fetched) must be called only once per lifetime, until dynamic config is fully deforked
 	}
 	return *autoscalingOptions
 }
@@ -355,7 +370,6 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxMemoryTotal:                   maxMemoryTotal,
 		MinMemoryTotal:                   minMemoryTotal,
 		GpuTotal:                         parsedGpuTotal,
-		NodeGroups:                       *nodeGroupsFlag,
 		EnforceNodeGroupMinSize:          *enforceNodeGroupMinSize,
 		ScaleDownDelayAfterAdd:           *scaleDownDelayAfterAdd,
 		ScaleDownDelayTypeLocal:          *scaleDownDelayTypeLocal,
@@ -464,6 +478,22 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxNodeSkipEvalTimeTrackerEnabled:            *maxNodeSkipEvalTimeTrackerEnabled,
 		CapacityQuotasEnabled:                        *capacityQuotasEnabled,
 		ScaleUpSimulationForSkippedNodeGroupsEnabled: *scaleUpSimulationForSkippedNodeGroupsEnabled,
+		NodeGroups: func() []string {
+			// Temporary + fork only, will be removed after CA is made restartable by PUT AP and have NodeGroups passed in by flags.
+			// Will fetch from ConfigMap rather than flags for now.
+			ConfigFetcher = dynamic.NewConfigFetcher(dynamic.ConfigFetcherOptions{
+				ConfigPath: "/opt/conf/autoscaler/settings.json",
+			})
+			if updatedConfig, err := ConfigFetcher.FetchConfigIfUpdated(); err != nil {
+				// Ideally we want this to be fatal, but that would resulted in CrashLoopBackOff in a race condition where the configmap takes time to initialize, delaying the initialization.
+				klog.Errorf("failed to fetch updated NodeGroups config: %v, could be resulted from the configmap not initialized yet", err)
+			} else if updatedConfig != nil {
+				// First fetch is always considered updated if not empty
+				klog.V(3).Infof("Fetched NodeGroups: %v", updatedConfig.NodeGroupSpecStrings())
+				return updatedConfig.NodeGroupSpecStrings()
+			}
+			return []string{}
+		}(),
 	}
 }
 

--- a/cluster-autoscaler/core/deallocate.go
+++ b/cluster-autoscaler/core/deallocate.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"reflect"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	klog "k8s.io/klog/v2"
+)
+
+// cleanUpTaintsFromDeallocatedNodes cleans up the ToBeDeleted taint from already deallocated nodes
+// so in the future they can be started and workloads can be scheduled on them
+// This is a best effort check for "Deallocation" because it can take sometime for cloudprovider
+// to apply the shutdown taint. In those cases, we resort to the unreacahble taint.
+// TODO: When removing deallocate mode, remove this func.
+func (a *StaticAutoscaler) cleanUpTaintsFromDeallocatedNodes(allNodes []*apiv1.Node) {
+	for _, node := range allNodes {
+		if !(taints.HasShutdownTaint(node) || taints.HasUnreachableTaint(node)) || !taints.HasToBeDeletedTaint(node) {
+			continue
+		}
+		nodeGroup, err := a.AutoscalingContext.CloudProvider.NodeGroupForNode(node)
+		if err != nil {
+			klog.V(5).Infof("Failed to get node group for %s: %v", node.Name, err)
+			continue
+		}
+		if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
+			klog.V(5).Infof("No node group for node %s, skipping", node)
+			continue
+		}
+		// TODO: remove this check when deallocate mode is removed
+		ng, ok := nodeGroup.(deallocate.PolicyNodeGroup)
+		if ok && ng.ScaleDownPolicy() == deallocate.Deallocate {
+			klog.V(3).Infof("Node %s is deallocated - attempting to remove taint from the node.", node.Name)
+			if _, err := taints.CleanToBeDeleted(node, a.ClientSet, a.AutoscalingContext.CordonNodeBeforeTerminate); err != nil {
+				klog.Errorf("error while removing taint from node %s: %s", node.Name, err.Error())
+			}
+		}
+	}
+}

--- a/cluster-autoscaler/core/scaledown/eligibility/deallocate.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/deallocate.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eligibility
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/deallocate"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	klog "k8s.io/klog/v2"
+)
+
+func processNodeGroupDeallocate(context *context.AutoscalingContext, node *apiv1.Node) bool {
+	nodeGroup, err := context.CloudProvider.NodeGroupForNode(node)
+	if err != nil {
+		klog.Errorf("Error while checking node group for %s: %v", node.Name, err)
+		return true
+	}
+	// Skip calculating unreadiness for already deallocated nodes. This is because CA attempts to delete unready unneeded nodes
+	if shouldSkipDeletionWhenDeallocated(nodeGroup, node) {
+		klog.V(3).Infof("Skipping %s from scale-down considerations as the nodegroup has Deallocate policy and node is currently deallocated", node.Name)
+		return true
+	}
+	return false
+}
+
+// shouldSkipDeletionWhenDeallocated returns true if we should skip the unneeded node calculation for this node
+// This is only done for Deallocation mode to avoid unnecessary candidate consideration/Deallocating those since
+// they remain in NotReady state
+func shouldSkipDeletionWhenDeallocated(nodeGroup cloudprovider.NodeGroup, node *apiv1.Node) bool {
+	policyNg, ok := nodeGroup.(deallocate.PolicyNodeGroup)
+	if ok && policyNg.ScaleDownPolicy() != deallocate.Deallocate {
+		return false
+	}
+	ready, _, _ := kube_util.GetReadinessState(node)
+	return taints.HasShutdownTaint(node) && !ready
+}

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -72,6 +72,10 @@ func (c *Checker) FilterOutUnremovable(autoscalingCtx *ca_context.AutoscalingCon
 	utilLogsQuota := klogx.NewLoggingQuota(20)
 
 	for _, node := range scaleDownCandidates {
+		if processNodeGroupDeallocate(autoscalingCtx, node) {
+			continue
+		}
+
 		nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(node.Name)
 		if err != nil {
 			klog.Errorf("Can't retrieve scale-down candidate %s from snapshot, err: %v", node.Name, err)

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -17,7 +17,7 @@ limitations under the License.
 package core
 
 import (
-	"context"
+	ctx "context"
 	"errors"
 	"fmt"
 	"maps"
@@ -70,6 +70,8 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	kube_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -309,6 +311,19 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 
 	stateUpdateStart := time.Now()
 
+	// Fetch the configmap to ensure apiserver connectivity
+	// Listers are backed by a cache which means in cases when apiserver
+	// is unresponsive, you may get stale data
+	// One example of a bad scenario is if the cache data is empty, all
+	// nodes will be counted as unregistered nodes and eventually deleted
+	// after the unregistered node 15 min deletion threshold
+	// See more: https://github.com/kubernetes/autoscaler/pull/3737
+	_, err := a.ClientSet.CoreV1().ConfigMaps(a.ConfigNamespace).Get(ctx.TODO(), a.AutoscalingContext.StatusConfigMapName, metav1.GetOptions{})
+	if err != nil && !kube_errors.IsNotFound(err) {
+		klog.Errorf("Failed to fetch %s configmap: %v, skipping iteration", a.AutoscalingContext.StatusConfigMapName, err)
+		return caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
+	}
+
 	var draSnapshot *drasnapshot.Snapshot
 	if a.AutoscalingContext.DynamicResourceAllocationEnabled && a.AutoscalingContext.DraProvider != nil {
 		var err error
@@ -407,6 +422,11 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		klog.Errorf("Failed to update cluster state: %v", typedErr)
 		return typedErr
 	}
+
+	// Cleanup Deletion taints from already deallocated nodes so that they dont prevent scheduling for the
+	// next workload
+	// TODO: when removing Deallocate mode, remove this call for cleanUpTaintsFromDeallocatedNodes
+	a.cleanUpTaintsFromDeallocatedNodes(allNodes)
 	metrics.UpdateDurationFromStart(metrics.UpdateState, stateUpdateStart)
 
 	scaleUpStatus := &status.ScaleUpStatus{Result: status.ScaleUpNotTried}
@@ -683,7 +703,7 @@ func (a *StaticAutoscaler) runScaleUpSalvo(
 	}
 
 	budget := a.AutoscalingContext.AutoscalingOptions.SalvoScaleUpBudget
-	salvoCtx, cancel := context.WithTimeout(context.Background(), budget)
+	salvoCtx, cancel := ctx.WithTimeout(ctx.Background(), budget)
 	defer cancel()
 
 	klog.Infof("Starting scale up salvo: %d pods to help, budget: %v", len(podsMap), budget)

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -6,7 +6,7 @@ godebug default=go1.26
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
-	github.com/Azure/azure-sdk-for-go-extensions v0.1.6
+	github.com/Azure/azure-sdk-for-go-extensions v0.1.8
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.4.0
@@ -90,7 +90,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
-	github.com/Azure/go-armbalancer v0.0.2 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.24 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
@@ -227,6 +226,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
+	gopkg.in/dnaeon/go-vcr.v3 v3.2.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -8,8 +8,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cyphar.com/go-pathrs v0.2.2 h1:y9w7hxbkr3zEL78Fjzeg4HEhs2xNy+fbwHiHGJJY2Xo=
 cyphar.com/go-pathrs v0.2.2/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
-github.com/Azure/azure-sdk-for-go-extensions v0.1.6 h1:EXGvDcj54u98XfaI/Cy65Ds6vNsIJeGKYf0eNLB1y4Q=
-github.com/Azure/azure-sdk-for-go-extensions v0.1.6/go.mod h1:27StPiXJp6Xzkq2AQL7gPK7VC0hgmCnUKlco1dO1jaM=
+github.com/Azure/azure-sdk-for-go-extensions v0.1.8 h1:x8Vu78C4r8mh6V2yQKQRSWLU+EYBVwFsf3XECddyb6s=
+github.com/Azure/azure-sdk-for-go-extensions v0.1.8/go.mod h1:4su5NjJwhqFH2B/5zJSKOz7hazfr2y38Iu6W4ZK0HYA=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 h1:fou+2+WFTib47nS+nz/ozhEBnvU96bKHy6LjRsY4E28=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0/go.mod h1:t76Ruy8AHvUAC8GfMWJMa0ElSbuIcO03NLpynfbgsPA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
@@ -58,8 +58,6 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfg
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3 h1:ZJJNFaQ86GVKQ9ehwqyAFE6pIfyicpuJ8IkVaPBc6/4=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3/go.mod h1:URuDvhmATVKqHBH9/0nOiNKk0+YcwfQ3WkK5PqHKxc8=
-github.com/Azure/go-armbalancer v0.0.2 h1:NVnxsTWHI5/fEzL6k6TjxPUfcB/3Si3+HFOZXOu0QtA=
-github.com/Azure/go-armbalancer v0.0.2/go.mod h1:yTg7MA/8YnfKQc9o97tzAJ7fbdVkod1xGsIvKmhYPRE=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.29 h1:I4+HL/JDvErx2LjyzaVxllw2lRDB5/BT2Bm4g20iqYw=

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -148,6 +148,18 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 				default:
 					trigger.Wait(previousRun)
 					previousRun, lastRun = lastRun, time.Now()
+
+					// Temporary + fork only, will be removed after CA is made restartable by PUT AP and have NodeGroups passed in by flags.
+					// Will restart as soon as it changes to OM-induced restart + mimic passing in by flags.
+					// Expect ConfigFetcher to be initialized. It contains the previous state to compare the difference to.
+					if updatedConfig, err := flags.ConfigFetcher.FetchConfigIfUpdated(); err != nil {
+						// Ideally we want this to be fatal, but that would resulted in CrashLoopBackOff in a race condition where the configmap takes time to initialize, delaying the initialization.
+						klog.Errorf("failed to fetch updated NodeGroups config: %v, could be resulted from the configmap not initialized yet", err)
+					} else if updatedConfig != nil {
+						klog.V(3).Infof("NodeGroups config has changed: %v, restarting...", updatedConfig.NodeGroupSpecStrings())
+						os.Exit(0)
+					}
+
 					loop.RunAutoscalerOnce(autoscaler, healthCheck, lastRun)
 				}
 			}
@@ -158,6 +170,17 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 					// TODO: handle graceful shutdown with context
 					return nil
 				case <-time.After(autoscalingOpts.ScanInterval):
+					// Temporary + fork only, will be removed after CA is made restartable by PUT AP and have NodeGroups passed in by flags.
+					// Will restart as soon as it changes to OM-induced restart + mimic passing in by flags.
+					// Expect ConfigFetcher to be initialized. It contains the previous state to compare the difference to.
+					if updatedConfig, err := flags.ConfigFetcher.FetchConfigIfUpdated(); err != nil {
+						// Ideally we want this to be fatal, but that would resulted in CrashLoopBackOff in a race condition where the configmap takes time to initialize, delaying the initialization.
+						klog.Errorf("failed to fetch updated NodeGroups config: %v, could be resulted from the configmap not initialized yet", err)
+					} else if updatedConfig != nil {
+						klog.V(3).Infof("NodeGroups config has changed: %v, restarting...", updatedConfig.NodeGroupSpecStrings())
+						os.Exit(0)
+					}
+
 					loop.RunAutoscalerOnce(autoscaler, healthCheck, time.Now())
 				}
 			}

--- a/cluster-autoscaler/utils/taints/deallocate.go
+++ b/cluster-autoscaler/utils/taints/deallocate.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taints
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	cloudproviderapi "k8s.io/cloud-provider/api"
+)
+
+// HasShutdownTaint returns true if cloudprovider node shutdown taint is applied on the node.
+func HasShutdownTaint(node *apiv1.Node) bool {
+	return HasTaint(node, cloudproviderapi.TaintNodeShutdown)
+}
+
+// HasUnreachableTaint returns true if unreachable taint is applied on the node.
+func HasUnreachableTaint(node *apiv1.Node) bool {
+	return HasTaint(node, apiv1.TaintNodeUnreachable)
+}

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -46,7 +46,7 @@ find_files() {
     \) -name '*.go'
 }
 
-DOCKER_IMAGE=`grep --color=none 'FROM golang' builder/Dockerfile | sed 's/FROM //'`
+DOCKER_IMAGE=`grep 'FROM .*golang' builder/Dockerfile | sed 's/FROM //'`
 GOFMT="docker run -v $(pwd):/code -w /code $DOCKER_IMAGE gofmt -s"
 
 bad_files=$(find_files | xargs $GOFMT -l)


### PR DESCRIPTION
## Release manifest

Release type: new minor version
Target branch: `Azure/cluster-autoscaler-1.36`
Upstream base: [`cluster-autoscaler-release-1.36`](https://github.com/kubernetes/autoscaler/tree/cluster-autoscaler-release-1.36)
Source commit: [`8301ef4ef`](https://github.com/Azure/autoscaler/commit/8301ef4ef) — `[1.35] cluster-autoscaler v1.35.2-aks (#74)` (tip of `cluster-autoscaler-release-1.35.2-aks`)

## Cherry-picks

| Working branch commit | Source commit | Message |
|---|---|---|
| [06aa8ea45](https://github.com/Azure/autoscaler/commit/06aa8ea45) | [8301ef4ef](https://github.com/Azure/autoscaler/commit/8301ef4ef) (PR [#74](https://github.com/Azure/autoscaler/pull/74)) | [1.35] cluster-autoscaler v1.35.2-aks |

## Resolved conflicts

1. `.devcontainer/devcontainer.json` — upstream 1.36 added a generic devcontainer; fork has Azure CAS Dev config. Resolution: kept fork version, bumped Go image to `go:1.26` to match upstream 1.36.

2. `builder/Dockerfile` — upstream uses `golang:1.26.0`; fork uses MCR base `mcr.microsoft.com/oss/go/microsoft/golang:1.25.0`. Resolution: kept fork MCR image, bumped to `1.26.0`.

3. `azure_vms_pool.go` — upstream 1.36 introduced `framework.NewPodInfo` constructor; fork used struct literal. Resolution: took upstream `NewPodInfo` (correct 1.36 API).

4. `test/Makefile` (3 hunks) — fork added `@echo` progress lines; upstream had nothing. Resolution: kept all fork echo lines.

5. `test/pkg/environment/environment.go` (2 hunks) — upstream simplified constructor; fork added validation guards. Node readiness: upstream used `SatisfyAll`; fork used explicit loop with better error messages. Resolution: kept fork for both.

6. `test/suites/scaleup/suite_test.go` (2 hunks) — upstream 1.36 extracted `runScaleUpDownFlow`/`withVMSSETag`/`newScaleUpDeployment` helpers and added ETag variant test; fork had inline test body. No deallocate mode overlap confirmed. Resolution: took upstream refactoring.

7. `clusterstate/clusterstate.go` (3 hunks):
   - `NodeGroupScaleUpSafety`: merged upstream `templateNodeInfoRegistry.GetNodeInfo` null-safety with fork's `IsNodeGroupHealthyDeallocate`
   - Node classification: kept both fork deallocate branch and upstream suspended node branch (deallocate first, then suspended — mutually exclusive states)
   - `newNodes` calculation: used upstream `calculateUpcomingNodesInNodeGroup` helper as base, overridden by fork's deallocate-specific formula when in deallocate mode

8. `clusterstate/clusterstate_test.go` — upstream updated `RegisterFailedScaleUp` to 4-arg signature (added `draDrivers`) and added `TestFailedScaleUpWithDra`, `TestFailedScaleUpWithDraAndGpu`, `TestGetUpcomingNodesSkipsWithoutScaleUpRequestOrBackoff`. Fork kept 3-arg + added backoff safety assertions. Resolution: took upstream 4-arg signature and all 3 new tests; inserted fork's backoff assertions after the updated assertion.

9. `config/flags/flags.go` — upstream added `CapacityQuotasEnabled` and `ScaleUpSimulationForSkippedNodeGroupsEnabled`; fork added `NodeGroups` ConfigFetcher. Resolution: kept both.

10. `core/static_autoscaler.go` — upstream used `"context"`; fork used `ctx "context"` alias. Resolution: kept fork's `ctx` alias (consistent with 1.35.2), updated one `context.WithTimeout` call to `ctx.WithTimeout`.

11. `go.mod` / `go.sum` — version conflicts on `cloud.google.com`, `cel.dev/expr`, `azure-sdk-for-go-extensions`, `golang.org/x/tools`, `google.golang.org/genproto`. Resolution: took higher upstream versions; kept fork's `azure-sdk-for-go-extensions v0.1.8` and `gopkg.in/dnaeon/go-vcr.v3 v3.2.0`.

12. **`main.go` ⚠️ — reviewers please pay special attention here.** Upstream 1.36 moved the autoscale loop into `mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {...}))` for controller-manager lifecycle and `ctx.Done()`-based graceful shutdown. The fork used a plain `for` loop with `time.Sleep` and `os.Exit(0)` restart logic for ConfigFetcher. Resolution: wrapped fork's ConfigFetcher polling (`flags.ConfigFetcher.FetchConfigIfUpdated()` + `os.Exit(0)`) inside the upstream manager wrapper in both the `FrequentLoopsEnabled` and normal scan paths. **Reviewers should verify that `os.Exit(0)` inside the manager `RunnableFunc` is safe and that the manager lifecycle handles this restart correctly.**

## master-azure-derived commits

None.

## Validation

- Build (`go build ./...`): ✅
- `go test -race ./cloudprovider/azure/...`: ✅
- Full CA unit tests: ✅ (`test/integration/controllers` fails on `BeforeSuite` — pre-existing, requires live API server, fails on upstream base too)